### PR TITLE
Aaron/behavioral cloning

### DIFF
--- a/atari_irl/behavioral_cloning.py
+++ b/atari_irl/behavioral_cloning.py
@@ -317,6 +317,8 @@ def dagger(
         policy, envs, policy_class, *, total_timesteps,
         nsteps=2048, noptepochs=4, nminibatches=32, n_trajectories=10
 ):
+    # This assumes we're already in a tensorflow context
+    # If we're not, then the policy clone won't work
     with CloningContext(
             policy, envs, policy_class,
             nsteps=nsteps, noptepochs=noptepochs, nminibatches=nminibatches,
@@ -341,12 +343,15 @@ def dagger(
             observations = np.vstack([observations, observations_t])
             actions      = np.vstack([actions, actions_t])
             logger.logkv(t)
+    return context.policy_clone
 
 
 def imitate(
         policy, envs, policy_class, *, n_iter=500,
         nsteps=2048, noptepochs=4, nminibatches=32, n_trajectories=10
 ):
+    # This assumes we're already in a tensorflow context
+    # If we're not, then the policy clone won't work
     with CloningContext(
             policy, envs, policy_class,
             nsteps=nsteps, noptepochs=noptepochs, nminibatches=nminibatches,
@@ -357,3 +362,4 @@ def imitate(
         update_policy(
             context.policy_clone, observations, actions, n_iter=n_iter
         )
+    return context.policy_clone

--- a/atari_irl/behavioral_cloning.py
+++ b/atari_irl/behavioral_cloning.py
@@ -1,0 +1,44 @@
+import tensorflow as tf
+
+from baselines.ppo2.policies import CnnPolicy
+
+from . import policies, training
+
+
+def update_policy(policy, trajectories):
+    pass
+
+
+def relabel_trajectory_observations(policy, trajectory):
+    return trajectory
+
+
+def dagger(
+        policy, envs, policy_class,
+        *,
+        total_timesteps, nsteps=2048, noptepochs=4, nminibatches=32
+):
+    batching_config = training.make_batching_config(
+        env=envs,
+        nsteps=nsteps, noptepochs=noptepochs, nminibatches=nminibatches
+    )
+    policy_clone = policy_class(
+        sess=tf.get_default_session(),
+        ob_space=envs.observation_space,
+        ac_space=envs.action_space,
+        nbatch=batching_config.nbatch,
+        nsteps=batching_config.nsteps
+    )
+    trajectories = policies.sample_trajectories(
+        model=policy.model, environments=envs, n_trajectories=10
+    )
+
+    for t in range(total_timesteps // batching_config.nbatch):
+        update_policy(policy_clone, trajectories)
+        cloned_policy_trajectories_t = policies.sample_trajectories(
+            model=policy_clone, environments=envs, n_trajectories=10
+        )
+        trajectories += relabel_trajectory_observations(
+            cloned_policy_trajectories_t
+        )
+

--- a/atari_irl/behavioral_cloning.py
+++ b/atari_irl/behavioral_cloning.py
@@ -342,3 +342,18 @@ def dagger(
             actions      = np.vstack([actions, actions_t])
             logger.logkv(t)
 
+
+def imitate(
+        policy, envs, policy_class, *, n_iter=500,
+        nsteps=2048, noptepochs=4, nminibatches=32, n_trajectories=10
+):
+    with CloningContext(
+            policy, envs, policy_class,
+            nsteps=nsteps, noptepochs=noptepochs, nminibatches=nminibatches,
+            n_trajectories=n_trajectories
+    ) as context:
+        observations, actions = context.base_trajectories
+        # Update the policy clone
+        update_policy(
+            context.policy_clone, observations, actions, n_iter=n_iter
+        )

--- a/atari_irl/behavioral_cloning.py
+++ b/atari_irl/behavioral_cloning.py
@@ -13,32 +13,57 @@ def relabel_trajectory_observations(policy, trajectory):
     return trajectory
 
 
-def dagger(
-        policy, envs, policy_class,
-        *,
-        total_timesteps, nsteps=2048, noptepochs=4, nminibatches=32
-):
-    batching_config = training.make_batching_config(
-        env=envs,
-        nsteps=nsteps, noptepochs=noptepochs, nminibatches=nminibatches
-    )
-    policy_clone = policy_class(
-        sess=tf.get_default_session(),
-        ob_space=envs.observation_space,
-        ac_space=envs.action_space,
-        nbatch=batching_config.nbatch,
-        nsteps=batching_config.nsteps
-    )
-    trajectories = policies.sample_trajectories(
-        model=policy.model, environments=envs, n_trajectories=10
-    )
+class CloningContext:
+    def __init__(
+            self, policy, envs, policy_class, *,
+            nsteps=2048, noptepochs=4, nminibatches=32, n_trajectories=10
+    ):
+        self.base_policy = policy
+        self.envs = envs
 
-    for t in range(total_timesteps // batching_config.nbatch):
-        update_policy(policy_clone, trajectories)
-        cloned_policy_trajectories_t = policies.sample_trajectories(
-            model=policy_clone, environments=envs, n_trajectories=10
+        self.n_trajectorie =n_trajectories
+        self.batching_config = training.make_batching_config(
+            env=envs,
+            nsteps=nsteps, noptepochs=noptepochs, nminibatches=nminibatches
         )
-        trajectories += relabel_trajectory_observations(
-            cloned_policy_trajectories_t
+
+        self.policy_clone = policy_class(
+            sess=tf.get_default_session(),
+            ob_space=envs.observation_space,
+            ac_space=envs.action_space,
+            nbatch=self.batching_config.nbatch,
+            nsteps=self.batching_config.nsteps
         )
+
+    def __enter__(self):
+        self.base_trajectories = policies.sample_trajectories(
+            model=self.base_policy, environments=self.envs,
+            n_trajectories=self.n_trajectories
+        )
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
+def dagger(
+        policy, envs, policy_class, *, total_timesteps,
+        nsteps=2048, noptepochs=4, nminibatches=32, n_trajectories=10,
+):
+    with CloningContext(
+            policy, envs, policy_class,
+            nsteps=nsteps, noptepochs=noptepochs, nminibatches=nminibatches,
+            n_trajectories=n_trajectories
+    ) as context:
+        trajectories = context.base_trajectories.copy()
+        for t in range(total_timesteps // context.batching_config.nbatch):
+            update_policy(context.policy_clone, trajectories)
+            cloned_policy_trajectories_t = policies.sample_trajectories(
+                model=context.policy_clone,
+                environments=envs,
+                n_trajectories=n_trajectories
+            )
+            trajectories += relabel_trajectory_observations(
+                cloned_policy_trajectories_t
+            )
 

--- a/atari_irl/behavioral_cloning.py
+++ b/atari_irl/behavioral_cloning.py
@@ -4,11 +4,119 @@ from baselines.ppo2.policies import CnnPolicy
 
 from . import policies, training
 import pickle
+from collections import namedtuple
 
+"""
+Training Code
+
+This should all get moved/factored into training.py of we actually like how
+it works, but for now it's specific to behavioral cloning
+"""
+# This controls all of the training information which don't change the input
+# shapes
+TrainingConfig = namedtuple('TrainingConfig', [
+    'learning_rate', 'max_grad_norm', 'optimizer'
+])
+
+def make_train_node(*, params, loss, training_config):
+    """
+    Creates the training node
+
+    Args:
+        params: tensorflow nodes for the policy that we can train
+        loss: tensorflow node for the loss to optimize
+        training_config: config for the training
+
+    Returns:
+        _train, a tensorflow operation which trains the policy when we run it
+    """
+    grads = tf.gradients(loss, params)
+
+    if training_config.max_grad_norm is not None:
+        grads, _grad_norm = tf.clip_by_global_norm(
+            grads, training_config.max_grad_norm
+        )
+    trainer = tf.train.AdamOptimizer(
+        learning_rate=training_config.learning_rate, epsilon=1e-5
+    )
+    _train = trainer.apply_gradients(grads)
+    return _train
+
+def make_dagger_imitation_cost(
+        *,
+        policy,
+        params,
+        training_config,
+        sess
+):
+    """
+    Set up the cost function for DAGGER
+
+    This is intended to make the code more modular by breaking up the creation
+    of a trainable model into a few different components:
+    - The Policy (a baselines ppo2 policy), which maps inputs to actions and
+      probabilities
+    - The TrainablePolicy (see below), which wraps a policy and sets up what
+      you need in order to train it
+    - A cost function, which defines what's actually minimized when you train
+
+    Thankfully, tensorflow makes it easy to set up a policy + train it, and
+    baselines gives us a bunch of policies, so the first 2 are pretty easy.
+
+    The policy interface exposes a few things, and we should restrict ourselves
+    to only using things which are genuinely exposed
+    - X: The input
+    - vf: The Value Function
+    - pd: The probability distribution
+    - pdtype: The type of the probability distribution
+
+    Args:
+        policy: Policy that we're trying to optimize
+        params: Parameters for the above policy
+            it seems like we could figure them out in this code, but it felt
+            safer to just grab these after initializing the policy and passing
+            them in, rather than needing to worry about whatever context we
+            may or may not be in in the future
+        training_config: Configuration spec for training
+        sess: tensorflow session to use for everything
+
+    Returns:
+        loss: The tensorflow node for the actual loss
+        train: A function accepting the appropriate inputs that trains
+    """
+    pass
+
+class TrainablePolicy:
+    def __init__(
+            self, *,
+            policy_class, make_cost, name='clone',
+            sess, envs, batching_config, training_config
+    ):
+        self.batching_config = batching_config
+        self.sess = sess
+        self.make_cost = make_cost
+
+        # Set up the actual tensorflow graph for our policy
+        with tf.variable_scope(name):
+            self.policy = policy_class(
+                sess=tf.get_default_session(),
+                ob_space=envs.observation_space,
+                ac_space=envs.action_space,
+                nbatch=batching_config.nbatch,
+                nsteps=batching_config.nsteps
+            )
+            params = tf.trainable_variables()
+
+            # construct the loss and start the training function
+            self.loss, self.train = make_cost(
+                policy=self.policy,
+                params=params,
+                training_config=training_config,
+                sess=self.sess
+            )
 
 def update_policy(policy, trajectories):
     pass
-
 
 def relabel_trajectory_observations(policy, trajectory):
     return trajectory
@@ -17,7 +125,7 @@ def relabel_trajectory_observations(policy, trajectory):
 class CloningContext:
     def __init__(
             self, policy, envs, policy_class, *,
-            start_trajectories=None,
+            start_trajectories=None, policy_name='clone',
             nsteps=2048, noptepochs=4, nminibatches=32, n_trajectories=10
     ):
         self.base_policy = policy
@@ -27,15 +135,23 @@ class CloningContext:
         self.base_trajectories = start_trajectories
         self.batching_config = training.make_batching_config(
             env=envs,
-            nsteps=nsteps, noptepochs=noptepochs, nminibatches=nminibatches
+            nsteps=nsteps,
+            noptepochs=noptepochs,
+            nminibatches=nminibatches
+        )
+        self.training_config = TrainingConfig(
+            learning_rate=3e-4,
+            max_grad_norm=0.5,
+            optimizer=tf.train.AdamOptimizer
         )
 
-        self.policy_clone = policy_class(
+        self.policy_clone = TrainablePolicy(
+            policy_class=CnnPolicy,
+            envs=envs,
+            make_cost=make_dagger_imitation_cost,
             sess=tf.get_default_session(),
-            ob_space=envs.observation_space,
-            ac_space=envs.action_space,
-            nbatch=self.batching_config.nbatch,
-            nsteps=self.batching_config.nsteps
+            batching_config=self.batching_config,
+            training_config=self.training_config
         )
 
     def __enter__(self):

--- a/atari_irl/behavioral_cloning.py
+++ b/atari_irl/behavioral_cloning.py
@@ -21,7 +21,7 @@ class CloningContext:
         self.base_policy = policy
         self.envs = envs
 
-        self.n_trajectorie =n_trajectories
+        self.n_trajectories = n_trajectories
         self.batching_config = training.make_batching_config(
             env=envs,
             nsteps=nsteps, noptepochs=noptepochs, nminibatches=nminibatches

--- a/atari_irl/environments.py
+++ b/atari_irl/environments.py
@@ -70,7 +70,7 @@ atari_modifiers = {
         wrap_env_with_args(NoopResetEnv, noop_max=30),
         wrap_env_with_args(MaxAndSkipEnv, skip=4),
         wrap_deepmind,
-        wrap_env_with_args(TimeLimitEnv, time_limit=5000)
+        #wrap_env_with_args(TimeLimitEnv, time_limit=5000)
     ],
     'vec_env_modifiers': [
         wrap_env_with_args(VecFrameStack, nstack=4)

--- a/atari_irl/environments.py
+++ b/atari_irl/environments.py
@@ -17,15 +17,18 @@ mujoco_modifiers = {
     'vec_env_modifiers': [vec_normalize]
 }
 
+
 # from baselines.common.cmd_util.make_atari_env
 def wrap_env_with_args(Wrapper, **kwargs):
     return lambda env: Wrapper(env, **kwargs)
+
 
 def noop_reset(noop_max):
     def _thunk(env):
         assert 'NoFrameskip' in env.spec.id
         return NoopResetEnv(env, noop_max=noop_max)
     return _thunk
+
 
 def atari_setup(env):
     # from baselines.common.atari_wrappers

--- a/atari_irl/training.py
+++ b/atari_irl/training.py
@@ -21,7 +21,6 @@ BatchingConfig = namedtuple('BatchingInfo', [
     'nbatch', 'nbatch_train', 'noptepochs', 'nenvs', 'nsteps', 'nminibatches'
 ])
 
-
 def train_steps(
         *, model, run_info, batching_config, lrnow, cliprangenow, nbatch_train
 ):

--- a/atari_irl/training.py
+++ b/atari_irl/training.py
@@ -18,7 +18,7 @@ RunInfo.train_args = lambda self: (
     self.obs, self.returns, self.masks, self.actions, self.values, self.neglogpacs
 )
 BatchingConfig = namedtuple('BatchingInfo', [
-    'nbatch', 'noptepochs', 'nenvs', 'nsteps', 'nminibatches'
+    'nbatch', 'nbatch_train', 'noptepochs', 'nenvs', 'nsteps', 'nminibatches'
 ])
 
 
@@ -97,6 +97,16 @@ def setup_policy(*, model_args, nenvs, ob_space, ac_space, env, save_env, checkp
     return policy
 
 
+def make_batching_config(*,env, nsteps, noptepochs, nminibatches):
+    nenvs = env.num_envs
+    nbatch = nenvs * nsteps
+    nbatch_train = nbatch // nminibatches
+    return BatchingConfig(
+        nbatch=nbatch, nbatch_train=nbatch_train, noptepochs=noptepochs,
+        nenvs=nenvs, nsteps=nsteps, nminibatches=nminibatches
+    )
+
+
 class Learner:
     def __init__(self, policy_class, env, *, total_timesteps, nsteps=2048,
                  ent_coef=0.0, lr=3e-4, vf_coef=0.5,  max_grad_norm=0.5,
@@ -117,24 +127,24 @@ class Learner:
 
         total_timesteps = int(total_timesteps)
 
-        nenvs = env.num_envs
         ob_space = env.observation_space
         ac_space = env.action_space
-        nbatch = nenvs * nsteps
-        nbatch_train = nbatch // nminibatches
-        batching_config = BatchingConfig(
-            nbatch=nbatch, noptepochs=noptepochs, nenvs=nenvs, nsteps=nsteps,
+
+        batching_config = make_batching_config(
+            env=env, nsteps=nsteps, noptepochs=noptepochs,
             nminibatches=nminibatches
         )
 
         model_args = dict(
-            policy=policy_class, ob_space=ob_space, ac_space=ac_space, nbatch_act=nenvs,
-            nbatch_train=nbatch_train, nsteps=nsteps, ent_coef=ent_coef,
-            vf_coef=vf_coef, max_grad_norm=max_grad_norm
+            policy=policy_class, ob_space=ob_space, ac_space=ac_space,
+            nbatch_act=batching_config.nenvs,
+            nbatch_train=batching_config.nbatch_train,
+            nsteps=batching_config.nsteps,
+            ent_coef=ent_coef, vf_coef=vf_coef, max_grad_norm=max_grad_norm
         )
 
         policy = setup_policy(
-            model_args=model_args, env=env, nenvs=nenvs, checkpoint=checkpoint,
+            model_args=model_args, env=env, nenvs=env.num_envs, checkpoint=checkpoint,
             ob_space=ob_space, ac_space=ac_space, save_env=save_env
         )
 
@@ -149,8 +159,8 @@ class Learner:
 
         # Set our last few run configurations
         self.callbacks = []
-        self.nbatch = nbatch
-        self.nupdates = total_timesteps // nbatch
+        self.nbatch = batching_config.nbatch
+        self.nupdates = total_timesteps // batching_config.nbatch
 
         # Initialize the objects that will change as we learn
         self._update = 1

--- a/scripts/arguments.py
+++ b/scripts/arguments.py
@@ -10,6 +10,12 @@ import argparse
 
 EXPERT_POLICY_FILENAME_ARG = '--expert_path'
 
+def add_bool_feature(parser, name):
+    feature_parser = parser.add_mutually_exclusive_group(required=False)
+    feature_parser.add_argument('--' + name, dest=name, action='store_true')
+    feature_parser.add_argument('--no-' + name, dest=name, action='store_false')
+    parser.set_defaults(**{name: True})
+
 
 def add_atari_args(parser):
     # see baselines.common.cmd_util
@@ -17,6 +23,7 @@ def add_atari_args(parser):
     parser.add_argument('--seed', help='RNG seed', type=int, default=0)
     parser.add_argument('--num_timesteps', type=int, default=int(10e6))
     parser.add_argument('--num_envs', type=int, default=8)
+    parser.add_argument('--policy_type', default='cnn')
 
 
 def add_trajectory_args(parser):


### PR DESCRIPTION
This adds and implementation of Behavioral Cloning via DAGGER, and also just optimizing the NLL of  some expert demonstrations.

In retrospect I'm not that big a fan of the CloningContext, though it was helpful in prototyping things. It could probably be replaced by a series of separate functions, for generating/reading expert trajectories, setting up the policy clone with the relevant batch sizes, and for reading the expert policy.