### PR TITLE
Aaron/rl step experiments

### DIFF
--- a/atari_irl/__init__.py
+++ b/atari_irl/__init__.py
@@ -1,1 +1,1 @@
-from . import utils, training, policies, environments
+from . import utils, training, policies, environments, irl

--- a/atari_irl/environments.py
+++ b/atari_irl/environments.py
@@ -70,7 +70,7 @@ atari_modifiers = {
         wrap_env_with_args(NoopResetEnv, noop_max=30),
         wrap_env_with_args(MaxAndSkipEnv, skip=4),
         wrap_deepmind,
-        wrap_env_with_args(TimeLimitEnv, time_limit=1000)
+        wrap_env_with_args(TimeLimitEnv, time_limit=500)
     ],
     'vec_env_modifiers': [
         wrap_env_with_args(VecFrameStack, nstack=4)

--- a/atari_irl/environments.py
+++ b/atari_irl/environments.py
@@ -70,7 +70,7 @@ atari_modifiers = {
         wrap_env_with_args(NoopResetEnv, noop_max=30),
         wrap_env_with_args(MaxAndSkipEnv, skip=4),
         wrap_deepmind,
-        #wrap_env_with_args(TimeLimitEnv, time_limit=5000)
+        wrap_env_with_args(TimeLimitEnv, time_limit=5000)
     ],
     'vec_env_modifiers': [
         wrap_env_with_args(VecFrameStack, nstack=4)

--- a/atari_irl/environments.py
+++ b/atari_irl/environments.py
@@ -173,8 +173,8 @@ class JustPress1Environment(gym.Env):
         self.action_space = gym.spaces.Discrete(6)
         self.observation_space = gym.spaces.Box(low=0, high=255, shape=(90, 90, 3))
 
-        self.black = np.zeros(self.observation_space.shape)
-        self.white = np.ones(self.observation_space.shape) * 255
+        self.black = np.zeros(self.observation_space.shape).astype(np.uint8)
+        self.white = np.ones(self.observation_space.shape).astype(np.uint8) * 255
         
         self.random_seed = 0
         self.np_random = np.random.RandomState(0)

--- a/atari_irl/environments.py
+++ b/atari_irl/environments.py
@@ -334,7 +334,7 @@ gym.envs.register(
 
 gym.envs.register(
     id='SimonSays-v0',
-    etnry_point='atari_irl.environments:SimonSaysEnvironment'
+    entry_point='atari_irl.environments:SimonSaysEnvironment'
 )
 
 env_mapping = {

--- a/atari_irl/environments.py
+++ b/atari_irl/environments.py
@@ -174,7 +174,7 @@ class JustPress1Environment(gym.Env):
         self.observation_space = gym.spaces.Box(low=0, high=255, shape=(90, 90, 3))
 
         self.black = np.zeros(self.observation_space.shape)
-        self.white = np.ones(self.observation_space.shape)
+        self.white = np.ones(self.observation_space.shape) * 255
         
         self.random_seed = 0
         self.np_random = np.random.RandomState(0)
@@ -190,9 +190,9 @@ class JustPress1Environment(gym.Env):
 
     def step(self, action):
         if action == 0:
-            return self.black, 0, self.is_done(), {}
+            return self.black, 0.0, self.is_done(), {}
         else:
-            return self.white, 1, self.is_done(), {}
+            return self.white, 1.0, self.is_done(), {}
 
     def reset(self):
         return self.black
@@ -220,9 +220,9 @@ class SimonSaysEnvironment(JustPress1Environment):
         return self.turns > 100
 
     def step(self, action):
-        reward = 0
+        reward = 0.0
         if isinstance(action, np.int64) and action == self.next_move or not isinstance(action, np.int64) and action[0] == self.next_move:
-            reward = 1
+            reward = 1.0
         obs = self.reset()
         return obs, reward, self.is_done(), {'next_move': self.next_move}
 
@@ -238,12 +238,10 @@ class VisionSaysEnvironment(SimonSaysEnvironment):
         self.zero = np.zeros(self.observation_space.shape)
         self.one = np.zeros(self.observation_space.shape)
 
-        self.zero[3, 2:7, :] = 1
-        self.zero[5, 2:7, :] = 1
-        self.zero[4, 2, :] = 1
-        self.zero[4, 6, :] = 1
-
-        self.one[4, 2:7, :] = 1
+        self.zero[3, 2:7, :] = 255
+        self.zero[5, 2:7, :] = 255
+        self.zero[4, 2, :] = 255
+        self.zero[4, 6, :] = 255
 
         self.obs_map = {
             0: self.zero,

--- a/atari_irl/environments.py
+++ b/atari_irl/environments.py
@@ -123,8 +123,7 @@ class VecOneHotEncodingEnv(VecEnvWrapper):
 easy_env_modifiers = {
     'env_modifiers': [
         wrap_deepmind,
-        wrap_env_with_args(TimeLimitEnv, time_limit=5000),
-        wrap_env_with_args(OneHotDecodingEnv)
+        wrap_env_with_args(TimeLimitEnv, time_limit=5000)
     ],
     'vec_env_modifiers': [
         wrap_env_with_args(VecFrameStack, nstack=4)
@@ -144,12 +143,13 @@ atari_modifiers = {
 }
 
 
-one_hot_atari_modifiers = {
-    'env_modifiers': atari_modifiers['env_modifiers'] + [
-        wrap_env_with_args(OneHotDecodingEnv)
-    ],
-    'vec_env_modifiers': atari_modifiers['vec_env_modifiers']
-}
+def one_hot_wrap_modifiers(modifiers):
+    return {
+        'env_modifiers': modifiers['env_modifiers'] + [
+            wrap_env_with_args(OneHotDecodingEnv)
+        ],
+        'vec_env_modifiers': modifiers['vec_env_modifiers']
+    }
 
 
 class ConstantStatistics(object):
@@ -316,14 +316,16 @@ class VisionSaysEnvironment(SimonSaysEnvironment):
         self.zero = np.zeros(self.observation_space.shape).astype(np.uint8)
         self.one = np.zeros(self.observation_space.shape).astype(np.uint8)
 
-        self.zero[3, 2:7, :] = 255
-        self.zero[5, 2:7, :] = 255
-        self.zero[4, 2, :] = 255
-        self.zero[4, 6, :] = 255
+        self.one[50:150, 120:128, :] = 255
+
+        self.zero[50:150, 100:108, :] = 255
+        self.zero[50:150, 140:148, :] = 255
+        self.zero[50:58, 100:148, :] = 255
+        self.zero[142:150, 100:148, :] = 255
 
         self.obs_map = {
-            0: self.zero,
-            1: self.one
+            0: self.one,
+            1: self.zero
         }
 
 
@@ -338,7 +340,7 @@ gym.envs.register(
 )
 
 env_mapping = {
-    'PongNoFrameskip-v4': one_hot_atari_modifiers,
+    'PongNoFrameskip-v4': atari_modifiers,
     'CartPole-v1': mujoco_modifiers,
     'VisionSays-v0': easy_env_modifiers,
     'SimonSays-v0': easy_env_modifiers

--- a/atari_irl/environments.py
+++ b/atari_irl/environments.py
@@ -94,7 +94,7 @@ atari_modifiers = {
         wrap_env_with_args(NoopResetEnv, noop_max=30),
         wrap_env_with_args(MaxAndSkipEnv, skip=4),
         wrap_deepmind,
-        wrap_env_with_args(TimeLimitEnv, time_limit=500)
+        wrap_env_with_args(TimeLimitEnv, time_limit=5000)
     ],
     'vec_env_modifiers': [
         wrap_env_with_args(VecFrameStack, nstack=4)

--- a/atari_irl/environments.py
+++ b/atari_irl/environments.py
@@ -70,7 +70,7 @@ atari_modifiers = {
         wrap_env_with_args(NoopResetEnv, noop_max=30),
         wrap_env_with_args(MaxAndSkipEnv, skip=4),
         wrap_deepmind,
-        wrap_env_with_args(TimeLimitEnv, time_limit=5000)
+        wrap_env_with_args(TimeLimitEnv, time_limit=1000)
     ],
     'vec_env_modifiers': [
         wrap_env_with_args(VecFrameStack, nstack=4)

--- a/atari_irl/environments.py
+++ b/atari_irl/environments.py
@@ -171,14 +171,19 @@ class JustPress1Environment(gym.Env):
         super().__init__()
         self.reward_range = (0, 1)
         self.action_space = gym.spaces.Discrete(6)
-        self.observation_space = gym.spaces.Box(low=0, high=255, shape=(90, 90, 3))
+        self.observation_space = gym.spaces.Box(low=0, high=255, shape=(210, 160, 3))
 
         self.black = np.zeros(self.observation_space.shape).astype(np.uint8)
         self.white = np.ones(self.observation_space.shape).astype(np.uint8) * 255
         
         self.random_seed = 0
         self.np_random = np.random.RandomState(0)
-        
+
+        class Ale:
+            def lives(self):
+                return 1
+        self.ale = Ale()
+
     def seed(self, seed=None):
         if seed is None:
             seed = 0
@@ -219,9 +224,16 @@ class SimonSaysEnvironment(JustPress1Environment):
         self.turns += 1
         return self.turns > 100
 
+    @staticmethod
+    def isint(n):
+        return isinstance(n, np.int64) or isinstance(n, int)
+
     def step(self, action):
         reward = 0.0
-        if isinstance(action, np.int64) and action == self.next_move or not isinstance(action, np.int64) and action[0] == self.next_move:
+        if (
+            self.isint(action) and action == self.next_move or
+            not self.isint(action) and action[0] == self.next_move
+        ):
             reward = 1.0
         obs = self.reset()
         return obs, reward, self.is_done(), {'next_move': self.next_move}
@@ -235,8 +247,8 @@ class SimonSaysEnvironment(JustPress1Environment):
 class VisionSaysEnvironment(SimonSaysEnvironment):
     def __init__(self):
         super().__init__()
-        self.zero = np.zeros(self.observation_space.shape)
-        self.one = np.zeros(self.observation_space.shape)
+        self.zero = np.zeros(self.observation_space.shape).astype(np.uint8)
+        self.one = np.zeros(self.observation_space.shape).astype(np.uint8)
 
         self.zero[3, 2:7, :] = 255
         self.zero[5, 2:7, :] = 255

--- a/atari_irl/environments.py
+++ b/atari_irl/environments.py
@@ -164,3 +164,74 @@ class VecGymEnv(Env):
     def reset(self, **kwargs):
         print("Reset")
         self.venv.reset(**kwargs)
+
+
+class JustPress1Environment(gym.Env):
+    def __init__(self):
+        super().__init__()
+        self.reward_range = (0, 1)
+        self.action_space = gym.spaces.Discrete(2)
+        self.observation_space = gym.spaces.Box(low=0, high=255, shape=(3, 9, 9))
+
+        self.black = np.zeros(self.observation_space.shape)
+        self.white = np.ones(self.observation_space.shape)
+
+    def step(self, action):
+        if action == 0:
+            return self.black, 0, False, {}
+        else:
+            return self.white, 1, False, {}
+
+    def reset(self):
+        return self.black
+
+    def render(self):
+        raise NotImplementedError
+
+
+class SimonSaysEnvironment(JustPress1Environment):
+    def __init__(self):
+        super().__init__()
+        self.seed = 0
+        self.state = np.random.seed(0)
+        self.next_move = self.state.randint(2)
+        self.obs_map = {
+            0: self.black,
+            1: self.white
+        }
+
+    def seed(self, seed=None):
+        if seed is None:
+            seed = 0
+        self.seed = seed
+        self.state = np.random.seed(seed)
+
+    def step(self, action):
+        reward = 0
+        if action == self.next_move:
+            reward = 1
+        obs = self.reset()
+        return obs, reward, False, {'next_move': self.next_move}
+
+    def reset(self):
+        self.next_move = self.state.randint(2)
+        return self.obs_map[self.next_move]
+
+
+class VisionSaysEnvironment(SimonSaysEnvironment):
+    def __init__(self):
+        super().__init__()
+        self.zero = np.zeros(self.observation_space.shape)
+        self.one = np.zeros(self.observation_space.shape)
+
+        self.zero[:, 3, 2:7] = 1
+        self.zero[:, 5, 2:7] = 1
+        self.zero[:, 4, 2] = 1
+        self.zero[:, 4, 6] = 1
+
+        self.one[:, 4, 2:7] = 1
+
+        self.obs_map = {
+            0: self.zero,
+            1: self.one
+        }

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -220,7 +220,7 @@ def cnn_net(x, actions=None, dout=1, **conv_kwargs):
     h = nature_cnn(x, **conv_kwargs)
     if actions is not None:
         # Actions must be one-hot coded, otherwise this won't make any sense
-        h = tf.concat(h, actions, axis=1)
+        h = tf.concat([h, actions], axis=1)
     h2 = tf.nn.relu(fc(h, 'action_state_vec', nh=20, init_scale=np.sqrt(2)))
     output = fc(h2, 'output', nh=dout, init_scale=np.sqrt(2))
     return output
@@ -279,11 +279,12 @@ class AtariAIRL(AIRL):
             with tf.variable_scope('discrim') as dvs:
                 rew_input = self.obs_t
                 with tf.variable_scope('reward'):
-                    if not self.state_only:
+                    if self.state_only:
                         self.reward = reward_arch(
                             rew_input, dout=1, **reward_arch_args
                         )
                     else:
+                        print("Not state only", self.act_t)
                         self.reward = reward_arch(
                             rew_input, actions=self.act_t,
                             dout=1, **reward_arch_args

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -334,9 +334,9 @@ class IRLRunner(IRLTRPO):
                 logger.log("Logging diagnostics...")
                 self.log_diagnostics(paths)
                 logger.log("Optimizing policy...")
-                for i in range(100):
-                    with logger.prefix('policy itr #%d | ' % i):
-                    self.optimize_policy(itr, samples_data)
+                #for i in range(1):
+                #    with logger.prefix('policy itr #%d | ' % i):
+                self.optimize_policy(itr, samples_data)
 
                 logger.log("Saving snapshot...")
                 params = self.get_itr_snapshot(itr, samples_data)  # , **kwargs)

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -410,7 +410,7 @@ def airl(venv, trajectories, discount, seed, log_dir, *,
                 'batch_size': 500,
                 'max_path_length': 100,
                 'irl_model_wt': irl_model_wt,
-                'entropy_weight': 0.1,
+                'entropy_weight': 0.01,
                 # paths substantially increase storage requirements
                 'store_paths': False,
                 'step_size': 0.01,
@@ -430,6 +430,7 @@ def airl(venv, trajectories, discount, seed, log_dir, *,
             )
 
             with rllab_logdir(algo=algo, dirname=log_dir):
+                print("Training!")
                 algo.train()
 
                 reward_params = irl_model.get_params()

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -307,7 +307,7 @@ class IRLRunner(IRLTRPO):
 
         logger.record_tabular("PointsGained", poss)
         logger.record_tabular("PointsLost", negs)
-
+        logger.record_tabular("NumTimesteps", sum([len(p['rewards']) for p in paths]))
         return paths
 
     def train(self):

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -378,15 +378,17 @@ def airl(venv, trajectories, discount, seed, log_dir, *,
 
             training_kwargs = {
                 'n_itr': 1000,
-                'batch_size': 10000,
-                'max_path_length': 5000,
+                'batch_size': 500,
+                'max_path_length': 1000,
                 'irl_model_wt': 1.0,
                 'entropy_weight': 0.1,
                 # paths substantially increase storage requirements
                 'store_paths': False,
+                'step_size': 0.01,
                 #'optimizer_args': {}
             }
             training_kwargs.update(training_cfg)
+            print(training_kwargs)
             algo = IRLRunner(
                 env=envs,
                 policy=policy,

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -378,12 +378,13 @@ def airl(venv, trajectories, discount, seed, log_dir, *,
 
             training_kwargs = {
                 'n_itr': 1000,
-                'batch_size': 1000,
-                'max_path_length': 500,
+                'batch_size': 10000,
+                'max_path_length': 5000,
                 'irl_model_wt': 1.0,
                 'entropy_weight': 0.1,
                 # paths substantially increase storage requirements
                 'store_paths': False,
+                #'optimizer_args': {}
             }
             training_kwargs.update(training_cfg)
             algo = IRLRunner(

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -211,10 +211,11 @@ class DiscreteIRLPolicy(StochasticPolicy, Serializable):
             venv.render()
 
     def train_step(self):
-        for i in range(30):
-            if i % 10 == 0:
-                print(i, safemean([epinfo['r'] for epinfo in self.learner._epinfobuf]))
-            self.learner.step()
+        #for i in range(30):
+        #    if i % 10 == 0:
+        #        print(i, safemean([epinfo['r'] for epinfo in self.learner._epinfobuf]))
+        self.learner.step()
+
 
 def cnn_net(x, actions=None, dout=1, **conv_kwargs):
     h = nature_cnn(x, **conv_kwargs)

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -62,13 +62,15 @@ class DiscreteIRLPolicy(StochasticPolicy, Serializable):
             print("Wrapping baseline with function")
             baselines_venv = fn(baseline_wrappers)
 
+        self.baselines_venv = baselines_venv
+
         with tf.variable_scope(name) as scope:
             self.learner = Learner(
                 policy_class=policy_model,
                 env=baselines_venv,
                 total_timesteps=10e6,
                 vf_coef=0.5, ent_coef=0.01,
-                nsteps=2048, noptepochs=4, nminibatches=4,
+                nsteps=128, noptepochs=4, nminibatches=4,
                 gamma=0.99, lam=0.95,
                 lr=lambda alpha: alpha * 2.5e-4,
                 cliprange=lambda alpha: alpha * 0.1
@@ -148,7 +150,7 @@ class DiscreteIRLPolicy(StochasticPolicy, Serializable):
 
     def train_step(self):
         self.learner.step()
-
+        self.learner.print_log(self.learner)
 
 def cnn_net(x, actions=None, dout=1, **conv_kwargs):
     h = nature_cnn(x, **conv_kwargs)

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -215,6 +215,7 @@ class DiscreteIRLPolicy(StochasticPolicy, Serializable):
         #    if i % 10 == 0:
         #        print(i, safemean([epinfo['r'] for epinfo in self.learner._epinfobuf]))
         self.learner.step()
+        self.learner.print_log(self.learner)
 
 
 def cnn_net(x, actions=None, dout=1, **conv_kwargs):
@@ -419,12 +420,14 @@ class IRLRunner(IRLTRPO):
                 logger.log("Optimizing policy...")
                 self.optimize_policy(itr, samples_data)
 
-                logger.log("Saving snapshot...")
-                params = self.get_itr_snapshot(itr, samples_data)  # , **kwargs)
-                if self.store_paths:
-                    params["paths"] = samples_data["paths"]
-                logger.save_itr_params(itr, params)
-                logger.log("Saved")
+                if itr % 250 == 0:
+                    logger.log("Saving snapshot...")
+                    params = self.get_itr_snapshot(itr, samples_data)  # , **kwargs)
+                    if self.store_paths:
+                        params["paths"] = samples_data["paths"]
+                    logger.save_itr_params(itr, params)
+                    logger.log("Saved")
+
                 logger.record_tabular('Time', time.time() - start_time)
                 logger.record_tabular('ItrTime', time.time() - itr_start_time)
                 logger.dump_tabular(with_prefix=False)
@@ -485,7 +488,7 @@ def airl(venv, trajectories, discount, seed, log_dir, *,
                 #'optimizer_args': {}
             }
             training_kwargs.update(training_cfg)
-            print(training_kwargs)
+            print("Training arguments: ", training_kwargs)
             print(
                 irl_model_wt,
                 zero_environment_reward,

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -69,7 +69,8 @@ class DiscreteIRLPolicy(StochasticPolicy, Serializable):
         self.probs = tf.nn.softmax(self.act_model.pd.logits)
         obs_var = self.act_model.X
 
-        self.get_param_values = lambda : sess.run(self.get_params())
+        self.tensor_values = lambda **kwargs: sess.run(self.get_params())
+
         self._f_dist = tensor_utils.compile_function(
             inputs=[obs_var],
             outputs=self.probs
@@ -308,7 +309,7 @@ def airl(venv, trajectories, discount, seed, log_dir, *,
 
                 # Must pickle policy rather than returning it directly,
                 # since parameters in policy will not survive across tf sessions.
-                policy_params = policy.get_param_values()
+                policy_params = policy.tensor_values()
 
     reward = model_cfg, reward_params
     return reward, policy_params

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -60,7 +60,7 @@ class DiscreteIRLPolicy(StochasticPolicy, Serializable):
         baselines_venv = envs._wrapped_env.venv
         for fn in baseline_wrappers:
             print("Wrapping baseline with function")
-            baselines_venv = fn(baseline_wrappers)
+            baselines_venv = fn(baselines_venv)
 
         self.baselines_venv = baselines_venv
 

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -356,7 +356,7 @@ class IRLRunner(IRLTRPO):
 
 # Heavily based on implementation in https://github.com/HumanCompatibleAI/population-irl/blob/master/pirl/irl/airl.py
 def airl(venv, trajectories, discount, seed, log_dir, *,
-         tf_cfg, model_cfg=None, policy_cfg=None, training_cfg={}):
+         tf_cfg, model_cfg=None, policy_cfg=None, training_cfg={}, ablation='normal'):
     envs = VecGymEnv(venv)
     envs = TfEnv(envs)
     experts = trajectories
@@ -378,8 +378,6 @@ def airl(venv, trajectories, discount, seed, log_dir, *,
 
             ablation_config = defaultdict(lambda: (1.0, True))
             ablation_config['train_rl'] = (0.0, False)
-
-            ablation = 'default'
             irl_model_wt, zero_environment_reward = ablation_config[ablation]
 
             training_kwargs = {

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -334,8 +334,6 @@ class IRLRunner(IRLTRPO):
                 logger.log("Logging diagnostics...")
                 self.log_diagnostics(paths)
                 logger.log("Optimizing policy...")
-                #for i in range(1):
-                #    with logger.prefix('policy itr #%d | ' % i):
                 self.optimize_policy(itr, samples_data)
 
                 logger.log("Saving snapshot...")

--- a/atari_irl/training.py
+++ b/atari_irl/training.py
@@ -71,6 +71,7 @@ def print_log(
     logger.logkv("explained_variance", float(ev))
     logger.logkv('eprewmean', safemean([epinfo['r'] for epinfo in epinfobuf]))
     logger.logkv('eplenmean', safemean([epinfo['l'] for epinfo in epinfobuf]))
+    print(safemean([epinfo['r'] for epinfo in epinfobuf]))
     logger.logkv('time_elapsed', tnow - tfirststart)
     for (lossval, lossname) in zip(lossvals, model.loss_names):
         logger.logkv(lossname, lossval)

--- a/atari_irl/utils.py
+++ b/atari_irl/utils.py
@@ -64,8 +64,11 @@ class TfContext:
 
 
 class EnvironmentContext:
-    def __init__(self, env_name, seed, n_envs=1, env_modifiers=list(), vec_env_modifiers=list()):
+    def __init__(self, *, env_name=None, make_env=None, seed, n_envs=1, env_modifiers=list(), vec_env_modifiers=list()):
         self.env_name = env_name
+        if make_env is None:
+            make_env = lambda: gym.make(self.env_name)
+        self.make_env = make_env
         self.n_envs = n_envs
         self.env_modifiers = env_modifiers
         self.vec_env_modifiers = vec_env_modifiers
@@ -74,7 +77,7 @@ class EnvironmentContext:
     def __enter__(self):
         def make_env(i):
             def _thunk():
-                env = gym.make(self.env_name)
+                env = self.make_env()
                 env.seed(i)
                 for fn in self.env_modifiers:
                     env = fn(env)

--- a/atari_irl/utils.py
+++ b/atari_irl/utils.py
@@ -86,7 +86,7 @@ class EnvironmentContext:
             return _thunk
 
         set_global_seeds(self.seed)
-        self.base_vec_env = DummyVecEnv([make_env(i + self.seed) for i in range(self.n_envs)])
+        self.base_vec_env = SubprocVecEnv([make_env(i + self.seed) for i in range(self.n_envs)])
         self.environments = self.base_vec_env
         for fn in self.vec_env_modifiers:
             self.environments = fn(self.environments)

--- a/atari_irl/utils.py
+++ b/atari_irl/utils.py
@@ -86,7 +86,7 @@ class EnvironmentContext:
             return _thunk
 
         set_global_seeds(self.seed)
-        self.base_vec_env = SubprocVecEnv([make_env(i + self.seed) for i in range(self.n_envs)])
+        self.base_vec_env = DummyVecEnv([make_env(i + self.seed) for i in range(self.n_envs)])
         self.environments = self.base_vec_env
         for fn in self.vec_env_modifiers:
             self.environments = fn(self.environments)

--- a/scripts/arguments.py
+++ b/scripts/arguments.py
@@ -1,14 +1,6 @@
 #from atari_irl import utils, environments, training, policies, irl
+from atari_irl import utils, environments
 
-import os.path as osp
-import os
-import argparse
-#
-#
-#
-#import pickle
-
-EXPERT_POLICY_FILENAME_ARG = '--expert_path'
 
 def add_bool_feature(parser, name):
     feature_parser = parser.add_mutually_exclusive_group(required=False)
@@ -41,6 +33,14 @@ def add_trajectory_args(parser):
     )
 
 
+def add_expert_args(parser):
+    parser.add_argument(
+        '--expert_path',
+        help='file for the expert policy',
+        default='experts/new_expert'
+    )
+
+
 def add_irl_args(parser):
     parser.add_argument('--irl_seed', help='seed for the IRL tensorflow session', type=int, default=0)
     parser.add_argument(
@@ -48,15 +48,40 @@ def add_irl_args(parser):
         help='filename for the IRL policy',
         default='irl_policy_params.pkl'
     )
+    parser.add_argument(
+        '--irl_reward_file',
+        help='filename for the IRL reward',
+        default='irl_reward.pkl'
+    )
     parser.add_argument('--discount', help='discount rate for the IRL policy', default=.99)
     parser.add_argument(
         '--n_iter',
         help='number of iterations for irl training',
         type=int, default=500
     )
+    parser.add_argument(
+        '--batch_size',
+        help='batch size for each iteration',
+        type=int, default=5000
+    )
+    parser.add_argument(
+        '--ablation',
+        help='what ablation to run',
+        choices=['none', 'train_rl'],
+        type=str, default='none'
+    )
 
 
+def env_context_for_args(args):
+    return utils.EnvironmentContext(
+        env_name=args.env,
+        n_envs=args.num_envs,
+        seed=args.seed,
+        **environments.env_mapping[args.env]
+    )
 
 
-
-
+def tf_context_for_args(args):
+    return utils.TfContext(
+        ncpu=args.n_cpu
+    )

--- a/scripts/arguments.py
+++ b/scripts/arguments.py
@@ -12,25 +12,22 @@ def add_bool_feature(parser, name):
 def add_atari_args(parser):
     # see baselines.common.cmd_util
     parser.add_argument('--env', help='environment ID', default='PongNoFrameskip-v4')
+    parser.add_argument('--n_cpu', help='Number of CPUs', default=8)
     parser.add_argument('--seed', help='RNG seed', type=int, default=0)
     parser.add_argument('--num_timesteps', type=int, default=int(10e6))
     parser.add_argument('--num_envs', type=int, default=8)
     parser.add_argument('--policy_type', default='cnn')
+    add_bool_feature(parser, 'one_hot_code')
 
 
 def add_trajectory_args(parser):
-    parser.add_argument('--n_cpu', help='Number of CPUs', default=8)
     parser.add_argument('--num_trajectories', help='number of trajectories', type=int, default=8)
-    parser.add_argument(
-        '--one_hot_code',
-        help='Whether or not to one hot code the actions',
-        type=bool, default=True
-    )
     parser.add_argument(
         '--trajectories_file',
         help='file to write the trajectories to',
         default='trajectories.pkl'
     )
+    add_bool_feature(parser, 'render')
 
 
 def add_expert_args(parser):
@@ -70,14 +67,23 @@ def add_irl_args(parser):
         choices=['none', 'train_rl'],
         type=str, default='none'
     )
+    parser.add_argument(
+        '--entropy_wt',
+        help='entropy_weight',
+        type=float, default=0.01
+    )
 
 
 def env_context_for_args(args):
+    env_modifiers = environments.env_mapping[args.env]
+    if args.one_hot_code:
+        env_modifiers = environments.one_hot_wrap_modifiers(env_modifiers)
+
     return utils.EnvironmentContext(
         env_name=args.env,
         n_envs=args.num_envs,
         seed=args.seed,
-        **environments.env_mapping[args.env]
+        **env_modifiers
     )
 
 

--- a/scripts/arguments.py
+++ b/scripts/arguments.py
@@ -19,7 +19,7 @@ def add_bool_feature(parser, name):
 
 def add_atari_args(parser):
     # see baselines.common.cmd_util
-    parser.add_argument('--env', help='environment ID', default='PongNoFrameskip-v0')
+    parser.add_argument('--env', help='environment ID', default='PongNoFrameskip-v4')
     parser.add_argument('--seed', help='RNG seed', type=int, default=0)
     parser.add_argument('--num_timesteps', type=int, default=int(10e6))
     parser.add_argument('--num_envs', type=int, default=8)

--- a/scripts/generate_trajectories.py
+++ b/scripts/generate_trajectories.py
@@ -1,17 +1,13 @@
-from atari_irl import utils, environments, policies
+from atari_irl import utils, policies
 import pickle
-from arguments import add_atari_args, add_trajectory_args, EXPERT_POLICY_FILENAME_ARG
+from arguments import add_atari_args, add_trajectory_args, add_expert_args, tf_context_for_args, env_context_for_args
 import argparse
 
 
 def generate_trajectories(args):
-    with utils.TfContext(args.n_cpu):
-        with utils.EnvironmentContext(
-                env_name=args.env,
-                n_envs=args.num_envs,
-                seed=args.seed,
-                **environments.atari_modifiers
-        ) as context:
+    utils.logger.configure()
+    with tf_context_for_args(args):
+        with env_context_for_args(args) as context:
             policy = policies.EnvPolicy.load(args.expert_path, context.environments)
             ts = policies.sample_trajectories(
                 model=policy.model,
@@ -29,14 +25,7 @@ if __name__ == '__main__':
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     add_atari_args(parser)
-    parser.add_argument(
-        EXPERT_POLICY_FILENAME_ARG,
-        help='file for the expert policy',
-        default='experts/default_expert'
-    )
-    parser.add_argument(
-        '--render', help='whether or not to render the sampled trajectories', default=True
-    )
+    add_expert_args(parser)
     add_trajectory_args(parser)
 
     args = parser.parse_args()

--- a/scripts/run_irl_policy.py
+++ b/scripts/run_irl_policy.py
@@ -1,19 +1,14 @@
 from atari_irl import utils, environments, irl
 import pickle
-from arguments import add_atari_args, add_trajectory_args, add_irl_args
+from arguments import add_atari_args, add_trajectory_args, add_irl_args, tf_context_for_args, env_context_for_args
 import argparse
 import tensorflow as tf
 from sandbox.rocky.tf.envs.base import TfEnv
 
 
 def run_irl_policy(args):
-    with utils.TfContext():
-        with utils.EnvironmentContext(
-                env_name=args.env,
-                n_envs=args.num_envs,
-                seed=args.seed,
-                **environments.one_hot_atari_modifiers
-        ) as context:
+    with tf_context_for_args(args):
+        with env_context_for_args(args) as context:
             envs = environments.VecGymEnv(context.environments)
             envs = TfEnv(envs)
 

--- a/scripts/train_airl.py
+++ b/scripts/train_airl.py
@@ -13,6 +13,8 @@ def train_airl(args):
         device_count={'GPU': 1},
         log_device_placement=True
     )
+    tf_cfg.gpu_options.allow_growth = True
+
     import pickle
     ts = pickle.load(open(args.trajectories_file, 'rb'))
 
@@ -21,7 +23,11 @@ def train_airl(args):
         reward, policy_params = irl.airl(
             context.environments, ts, args.discount, args.irl_seed, logger.get_dir(),
             tf_cfg=tf_cfg,
-            training_cfg={'n_itr': args.n_iter, 'batch_size': args.n_iter},
+            training_cfg={
+                'n_itr': args.n_iter,
+                'batch_size': args.batch_size,
+                'entropy_weight': args.entropy_wt
+            },
             policy_cfg=irl.policy_config(args),
             reward_model_cfg=irl.reward_model_config(args),
             ablation=args.ablation

--- a/scripts/train_airl.py
+++ b/scripts/train_airl.py
@@ -11,7 +11,7 @@ def train_airl(args):
         intra_op_parallelism_threads=args.n_cpu,
         inter_op_parallelism_threads=args.n_cpu,
         device_count={'GPU': 1},
-        log_device_placement=True
+        log_device_placement=False
     )
     tf_cfg.gpu_options.allow_growth = True
 

--- a/scripts/train_airl.py
+++ b/scripts/train_airl.py
@@ -1,6 +1,5 @@
 from atari_irl import utils, environments, irl
-import pickle
-from arguments import add_atari_args, add_trajectory_args, add_irl_args
+from arguments import add_atari_args, add_trajectory_args, add_irl_args, env_context_for_args
 import argparse
 from baselines import logger
 import tensorflow as tf
@@ -17,25 +16,19 @@ def train_airl(args):
     import pickle
     ts = pickle.load(open(args.trajectories_file, 'rb'))
 
-    env_config = environments.one_hot_atari_modifiers
-    if not args.one_hot_code:
-        env_config = environments.atari_modifiers
-    with utils.EnvironmentContext(
-            env_name=args.env,
-            n_envs=args.num_envs,
-            seed=args.seed,
-            **env_config
-    ) as context:
+    with env_context_for_args(args) as context:
         logger.configure()
         reward, policy_params = irl.airl(
             context.environments, ts, args.discount, args.irl_seed, logger.get_dir(),
             tf_cfg=tf_cfg,
-            training_cfg={'n_itr': args.n_iter},
-            policy_cfg=irl.policy_config(args)
+            training_cfg={'n_itr': args.n_iter, 'batch_size': args.n_iter},
+            policy_cfg=irl.policy_config(args),
+            reward_model_cfg=irl.reward_model_config(args),
+            ablation=args.ablation
         )
 
-        import pickle
         pickle.dump(policy_params, open(args.irl_policy_file, 'wb'))
+        pickle.dump(reward, open(args.irl_reward_file, 'wb'))
 
 
 if __name__ == '__main__':

--- a/scripts/train_expert.py
+++ b/scripts/train_expert.py
@@ -1,6 +1,6 @@
-from atari_irl import utils, environments, training, policies
+from atari_irl import utils, training, policies
 import argparse
-from arguments import add_atari_args, EXPERT_POLICY_FILENAME_ARG, add_bool_feature
+from arguments import add_atari_args, add_expert_args, env_context_for_args, tf_context_for_args
 from baselines.ppo2.policies import MlpPolicy, CnnPolicy
 import os.path as osp
 import os
@@ -8,19 +8,8 @@ import os
 
 def train_expert(args):
     utils.logger.configure()
-
-    modifiers = environments.atari_modifiers
-    if not args.atari:
-        modifiers = environments.mujoco_modifiers
-    print(args.atari, modifiers)
-
-    with utils.TfContext():
-        with utils.EnvironmentContext(
-                env_name=args.env,
-                n_envs=args.num_envs,
-                seed=args.seed,
-                **modifiers
-        ) as context:
+    with tf_context_for_args(args):
+        with env_context_for_args(args) as context:
             learner = training.Learner(
                 CnnPolicy if args.policy_type == 'cnn' else MlpPolicy,
                 context.environments,
@@ -60,18 +49,6 @@ if __name__ == '__main__':
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     add_atari_args(parser)
-    parser.add_argument(
-        EXPERT_POLICY_FILENAME_ARG,
-        help='file for the expert policy',
-        default='experts/new_expert'
-    )
-
-    add_bool_feature(parser, 'atari')
-
-    parser.add_argument(
-        '--is_atari',
-        help='Whether or not this is an atari environment',
-        type=bool, default=True
-    )
+    add_expert_args(parser)
     args = parser.parse_args()
     train_expert(args)

--- a/scripts/train_expert.py
+++ b/scripts/train_expert.py
@@ -51,4 +51,6 @@ if __name__ == '__main__':
     add_atari_args(parser)
     add_expert_args(parser)
     args = parser.parse_args()
+
+    assert not args.one_hot_code
     train_expert(args)


### PR DESCRIPTION
This fixes a lot of problems, and should hopefully be our last disorganized pull request.

Its main contribution is getting the very easy vision environments to work, and demonstrating that the AIRL system can work end to end. There's a bunch of issues with the easy environments, namely that you don't have any control over the environment, and so the history is exchangable, which is not really what one wants in a control setting.

This masks the main problem with the Pong environment -- namely that we're sampling from the environment in both the Discriminator update and the IRL update in a way that means that the discriminator and IRL step are looking at different trajectories, and throwing off each other's count. This is why the train_rl ablation results in quickly getting up to ~-12 points, then stopping. It's not actually scoring, it's just cutting the episode length in half.