### PR TITLE
Aaron/refactor airl to be more usable

### DIFF
--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -553,8 +553,12 @@ def get_training_kwargs(
 
 
 # Heavily based on implementation in https://github.com/HumanCompatibleAI/population-irl/blob/master/pirl/irl/airl.py
-def airl(venv, trajectories, discount, seed, log_dir, *,
-         tf_cfg, reward_model_cfg=None, policy_cfg=None, training_cfg={}, ablation='normal'):
+def airl(
+        venv, trajectories, seed, log_dir,
+        *,
+        tf_cfg, reward_model_cfg=None, policy_cfg=None, training_cfg=None,
+        ablation='normal'
+):
     with IRLContext(tf_cfg, seed=seed) as irl_context:
         training_kwargs = get_training_kwargs(
             venv=venv,

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -455,6 +455,8 @@ class IRLContext:
         self.sess_context.__enter__()
         tf.set_random_seed(self.seed)
 
+        return self
+
     def __exit__(self, *args):
         self.sess_context.__exit__(*args)
         self.tg_context.__exit__(*args)

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -313,7 +313,7 @@ class AtariAIRL(AIRL):
             self._make_param_ops(_vs)
 
 
-def policy_config(args):
+def policy_config():
     return {
         'policy': DiscreteIRLPolicy,
         'policy_model': CnnPolicy
@@ -330,7 +330,7 @@ def make_irl_policy(policy_cfg, envs, sess):
     )
 
 
-def reward_model_config(args):
+def reward_model_config():
     return {
         'model': AtariAIRL,
         'state_only': False,
@@ -470,9 +470,9 @@ def airl(venv, trajectories, discount, seed, log_dir, *,
 
     with IRLContext(tf_cfg) as irl_context:
         if reward_model_cfg is None:
-            reward_model_cfg = reward_model_config(None)
+            reward_model_cfg = reward_model_config()
         if policy_cfg is None:
-            policy_cfg = policy_config(None)
+            policy_cfg = policy_config()
 
         irl_model = make_irl_model(reward_model_cfg, env_spec=envs.spec, expert_trajs=experts)
 

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -508,11 +508,10 @@ def training_config(
 
 def get_training_kwargs(
         *,
-        venv, irl_context,
-        reward_model_cfg, policy_cfg, training_cfg,
-        expert_trajectories, ablation
+        venv, irl_context, expert_trajectories,
+        ablation='normal',
+        reward_model_cfg=None, policy_cfg=None, training_cfg=None
 ):
-    assert 'discount' in training_cfg
     envs = venv
     envs = VecGymEnv(envs)
     envs = TfEnv(envs)

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -468,7 +468,7 @@ def airl(venv, trajectories, discount, seed, log_dir, *,
     envs = TfEnv(envs)
     experts = trajectories
 
-    with IRLContext(tf_cfg) as irl_context:
+    with IRLContext(tf_cfg, seed=seed) as irl_context:
         if reward_model_cfg is None:
             reward_model_cfg = reward_model_config()
 

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -471,8 +471,6 @@ def airl(venv, trajectories, discount, seed, log_dir, *,
     with IRLContext(tf_cfg) as irl_context:
         if reward_model_cfg is None:
             reward_model_cfg = reward_model_config()
-        if policy_cfg is None:
-            policy_cfg = policy_config()
 
         irl_model = make_irl_model(reward_model_cfg, env_spec=envs.spec, expert_trajs=experts)
 
@@ -488,6 +486,8 @@ def airl(venv, trajectories, discount, seed, log_dir, *,
             env_wrappers
         ) = ablation_config[ablation]
 
+        if policy_cfg is None:
+            policy_cfg = policy_config()
         policy_cfg['baseline_wrappers'] = env_wrappers
         policy = make_irl_policy(policy_cfg, envs, irl_context.sess)
 

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -507,35 +507,27 @@ def airl(venv, trajectories, discount, seed, log_dir, *,
         policy_cfg.update(ablation_policy_modifiers)
         policy = make_irl_policy(policy_cfg, envs, irl_context.sess)
 
-        training_kwargs = {
-            'n_itr': 1000,
-            'batch_size': 500,
-            'max_path_length': 100,
-            'irl_model_wt': irl_model_wt,
-            'entropy_weight': 0.01,
-            # paths substantially increase storage requirements
-            'store_paths': False,
-            'step_size': 0.01,
-            #'optimizer_args': {}
-        }
-        training_kwargs.update(training_cfg)
-        print("Training arguments: ", training_kwargs)
-        print(
-            irl_model_wt,
-            zero_environment_reward,
-            env_wrappers
-        )
-
-        algo = IRLRunner(
+        training_kwargs = dict(
             env=envs,
             policy=policy,
             irl_model=irl_model,
-            discount=discount,
             sampler_args=dict(n_envs=venv.num_envs),
-            zero_environment_reward=zero_environment_reward,
+            n_itr=1000,
+            discount=discount,
+            batch_size=500,
+            max_path_length=100,
+            entropy_weight=0.01,
+            step_size=0.01,
+            # paths substantially increase storage requirements
+            store_paths=False,
             baseline=ZeroBaseline(env_spec=envs.spec),
-            **training_kwargs
+            #optimizer_args={}
         )
+        training_kwargs.update(training_cfg)
+        training_kwargs.update(ablation_training_modifiers)
+
+        print("Training arguments: ", training_kwargs)
+        algo = IRLRunner(**training_kwargs)
 
         with rllab_logdir(algo=algo, dirname=log_dir):
             print("Training!")

--- a/environment.yml
+++ b/environment.yml
@@ -3,81 +3,86 @@ channels:
   - pytorch
   - defaults
 dependencies:
-  - alabaster=0.7.11
-  - asn1crypto=0.24.0
-  - babel=2.6.0
-  - binutils_impl_linux-64=2.28.1
-  - binutils_linux-64=7.2.0
-  - ca-certificates=2018.03.07
-  - certifi=2018.4.16
-  - cffi=1.11.5
-  - chardet=3.0.4
-  - cryptography=2.2.2
-  - cudatoolkit=9.0
-  - cudnn=7.1.2
-  - docutils=0.14
-  - gcc_impl_linux-64=7.2.0
-  - gcc_linux-64=7.2.0
-  - gxx_impl_linux-64=7.2.0
-  - gxx_linux-64=7.2.0
-  - idna=2.7
-  - imagesize=1.0.0
-  - intel-openmp=2018.0.3
-  - jinja2=2.10
-  - libedit=3.1.20170329
-  - libffi=3.2.1
-  - libgcc-ng=7.2.0
-  - libgfortran-ng=7.2.0
-  - libgpuarray=0.7.6
-  - libstdcxx-ng=7.2.0
-  - mako=1.0.7
-  - markupsafe=1.0
-  - mkl=2018.0.3
-  - mkl-service=1.1.2
-  - mkl_fft=1.0.1
-  - mkl_random=1.0.1
-  - ncurses=6.1
-  - ninja=1.8.2
-  - numpy=1.14.2
-  - numpydoc=0.8.0
-  - openssl=1.0.2o
-  - packaging=17.1
-  - pandas=0.23.0
-  - pip=10.0.1
-  - pycparser=2.18
-  - pygments=2.2.0
-  - pygpu=0.7.6
-  - pyopenssl=18.0.0
-  - pyparsing=2.2.0
-  - pysocks=1.6.8
-  - python=3.6.5
-  - python-dateutil=2.7.3
-  - pytz=2018.4
-  - readline=7.0
-  - requests=2.19.1
-  - scipy=1.1.0
-  - setuptools=39.2.0
-  - six=1.11.0
-  - snowballstemmer=1.2.1
-  - sphinx=1.7.5
-  - sphinxcontrib=1.0
-  - sphinxcontrib-websupport=1.1.0
-  - sqlite=3.24.0
-  - theano=1.0.2
-  - tk=8.6.7
-  - urllib3=1.23
-  - wheel=0.31.1
-  - xz=5.2.4
-  - zlib=1.2.11
-  - cuda90=1.0
-  - pytorch=0.4.0
+  - alabaster=0.7.11=py36_0
+  - asn1crypto=0.24.0=py36_0
+  - atomicwrites=1.1.5=py36_0
+  - attrs=18.1.0=py36_0
+  - babel=2.6.0=py36_0
+  - binutils_impl_linux-64=2.28.1=had2808c_3
+  - binutils_linux-64=7.2.0=had2808c_27
+  - ca-certificates=2018.03.07=0
+  - certifi=2018.4.16=py36_0
+  - cffi=1.11.5=py36h9745a5d_0
+  - chardet=3.0.4=py36h0f667ec_1
+  - cryptography=2.2.2=py36h14c3975_0
+  - cudatoolkit=9.0=h13b8566_0
+  - cudnn=7.1.2=cuda9.0_0
+  - docutils=0.14=py36hb0f60f5_0
+  - gcc_impl_linux-64=7.2.0=habb00fd_3
+  - gcc_linux-64=7.2.0=h550dcbe_27
+  - gxx_impl_linux-64=7.2.0=hdf63c60_3
+  - gxx_linux-64=7.2.0=h550dcbe_27
+  - idna=2.7=py36_0
+  - imagesize=1.0.0=py36_0
+  - intel-openmp=2018.0.3=0
+  - jinja2=2.10=py36ha16c418_0
+  - libedit=3.1.20170329=h6b74fdf_2
+  - libffi=3.2.1=hd88cf55_4
+  - libgcc-ng=7.2.0=hdf63c60_3
+  - libgfortran-ng=7.2.0=hdf63c60_3
+  - libgpuarray=0.7.6=h14c3975_0
+  - libstdcxx-ng=7.2.0=hdf63c60_3
+  - mako=1.0.7=py36h0727276_0
+  - markupsafe=1.0=py36hd9260cd_1
+  - mkl=2018.0.3=1
+  - mkl-service=1.1.2=py36h17a0993_4
+  - mkl_fft=1.0.1=py36h3010b51_0
+  - mkl_random=1.0.1=py36h629b387_0
+  - more-itertools=4.3.0=py36_0
+  - ncurses=6.1=hf484d3e_0
+  - ninja=1.8.2=py36h6bb024c_1
+  - numpy=1.14.2=py36hdbf6ddf_1
+  - numpydoc=0.8.0=py36_0
+  - openssl=1.0.2o=h20670df_0
+  - packaging=17.1=py36_0
+  - pandas=0.23.0=py36h637b7d7_0
+  - pip=10.0.1=py36_0
+  - pluggy=0.7.1=py36_0
+  - py=1.5.4=py36_0
+  - pycparser=2.18=py36hf9f622e_1
+  - pygments=2.2.0=py36h0d3125c_0
+  - pygpu=0.7.6=py36h3010b51_0
+  - pyopenssl=18.0.0=py36_0
+  - pyparsing=2.2.0=py36hee85983_1
+  - pysocks=1.6.8=py36_0
+  - pytest=3.7.1=py36_0
+  - python=3.6.5=hc3d631a_2
+  - python-dateutil=2.7.3=py36_0
+  - pytz=2018.4=py36_0
+  - readline=7.0=ha6073c6_4
+  - requests=2.19.1=py36_0
+  - scipy=1.1.0=py36hfc37229_0
+  - setuptools=39.2.0=py36_0
+  - six=1.11.0=py36h372c433_1
+  - snowballstemmer=1.2.1=py36h6febd40_0
+  - sphinx=1.7.5=py36_0
+  - sphinxcontrib=1.0=py36h6d0f590_1
+  - sphinxcontrib-websupport=1.1.0=py36_1
+  - sqlite=3.24.0=h84994c4_0
+  - theano=1.0.2=py36h6bb024c_0
+  - tk=8.6.7=hc745277_3
+  - urllib3=1.23=py36_0
+  - wheel=0.31.1=py36_0
+  - xz=5.2.4=h14c3975_4
+  - zlib=1.2.11=ha838bed_2
+  - cuda90=1.0=h6433d27_0
+  - pytorch=0.4.0=py36_cuda9.0.176_cudnn7.1.2_1
   - pip:
     - absl-py==0.2.2
     - adversarial-irl==0.1
     - astor==0.6.2
+    - atari-irl==0.1
     - atari-py==0.1.1
-    - atomicwrites==1.1.5
-    - attrs==18.1.0
     - backcall==0.1.0
     - baselines==0.1.5
     - bleach==1.5.0
@@ -109,10 +114,10 @@ dependencies:
     - jupyter-client==5.2.3
     - jupyter-core==4.4.0
     - kiwisolver==1.0.1
+    - lasagne==0.1
     - markdown==2.6.11
     - matplotlib==2.2.2
     - mistune==0.8.3
-    - more-itertools==4.2.0
     - mpi4py==3.0.0
     - mujoco-py==1.50.1.56
     - nbconvert==5.3.1
@@ -125,17 +130,14 @@ dependencies:
     - pexpect==4.6.0
     - pickleshare==0.7.4
     - pillow==5.1.0
-    - pluggy==0.6.0
     - progressbar2==3.38.0
     - prompt-toolkit==1.0.15
     - protobuf==3.6.0
     - psutil==5.4.6
     - ptyprocess==0.6.0
-    - py==1.5.4
     - pyglet==1.3.2
     - pyopengl==3.1.0
     - pyprind==2.11.2
-    - pytest==3.6.2
     - python-utils==2.3.0
     - pyyaml==3.12
     - pyzmq==17.0.0

--- a/scripts/train_airl.py
+++ b/scripts/train_airl.py
@@ -28,8 +28,8 @@ def train_airl(args):
                 'batch_size': args.batch_size,
                 'entropy_weight': args.entropy_wt
             },
-            policy_cfg=irl.policy_config(args),
-            reward_model_cfg=irl.reward_model_config(args),
+            policy_cfg=irl.policy_config(),
+            reward_model_cfg=irl.reward_model_config(),
             ablation=args.ablation
         )
 


### PR DESCRIPTION
This does a refactor in preparation for the IRL code being testable. I'm not super happy that I wound up changing things this much, but the improved test coverage should make it easier to check that everything sticks to its interface, and I can run experiments tonight to verify that everything that used to work still works.

This also suggests a refactor for how we handle command line arguments + default keyword arguments.

```
class DefaultedArgument(NamedTuple):
    name: str
    type: type # hopefully python is fine with this
    default: Any

class ArgumentConstructor:
    def __init__(self, arguments: List[DefaultedArgument]):
        self.arguments = arguments

    def render_args(self, **kwargs):
        # raise an error if kwargs isn't in args
        # basically turn self.arguments into a dict, then update it with kwargs

    @classmethod
    def make_entity(**kwargs):
        # this should vary by implementation, i.e. IRLModel, Policy, etc.
        # takes in a rendered args dictionary, so its a classmethod
        raise NotImplemented()

    def add_command_line_args(self, parser):
         pass

    def render_command_line_args(self, args):
        # loop through arguments  and extract the ones that exist, then render them 
```