### PR TITLE
Aaron/add more to agent infos

### DIFF
--- a/atari_irl/environments.py
+++ b/atari_irl/environments.py
@@ -130,12 +130,17 @@ easy_env_modifiers = {
     ]
 }
 
+import functools
+# Episode Life causes us to not actually reset the environments, which means
+# that interleaving, and even running the normal sampler a bunch of times
+# will give us super short trajectories. Right now we set it to false, but
+# that's not an obviously correct way to handle the problem
 atari_modifiers = {
     'env_modifiers': [
         wrap_env_with_args(NoopResetEnv, noop_max=30),
         wrap_env_with_args(MaxAndSkipEnv, skip=4),
-        wrap_deepmind,
-        wrap_env_with_args(TimeLimitEnv, time_limit=5000)
+        functools.partial(wrap_deepmind, episode_life=False),
+        #wrap_env_with_args(TimeLimitEnv, time_limit=5000)
     ],
     'vec_env_modifiers': [
         wrap_env_with_args(VecFrameStack, nstack=4)

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -113,14 +113,6 @@ class DiscreteIRLPolicy(StochasticPolicy, Serializable):
         )
 
     def get_actions(self, observations):
-        """
-
-        Args:
-            observations:
-
-        Returns:
-
-        """
         N = observations.shape[0]
         batch_size = self.act_model.X.shape[0].value
 
@@ -211,9 +203,6 @@ class DiscreteIRLPolicy(StochasticPolicy, Serializable):
             venv.render()
 
     def train_step(self):
-        #for i in range(30):
-        #    if i % 10 == 0:
-        #        print(i, safemean([epinfo['r'] for epinfo in self.learner._epinfobuf]))
         self.learner.step()
         self.learner.print_log(self.learner)
 

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -558,7 +558,7 @@ def get_training_kwargs(
     training_kwargs.update(training_cfg)
     training_kwargs.update(ablation_training_modifiers)
 
-    return training_kwargs
+    return training_kwargs, policy_cfg, reward_model_cfg
 
 
 # Heavily based on implementation in https://github.com/HumanCompatibleAI/population-irl/blob/master/pirl/irl/airl.py
@@ -569,7 +569,7 @@ def airl(
         ablation='normal'
 ):
     with IRLContext(tf_cfg, seed=seed) as irl_context:
-        training_kwargs = get_training_kwargs(
+        training_kwargs, _, reward_model_cfg = get_training_kwargs(
             venv=venv,
             irl_context=irl_context,
             reward_model_cfg=reward_model_cfg,
@@ -580,9 +580,8 @@ def airl(
         )
         print("Training arguments: ", training_kwargs)
         algo = IRLRunner(**training_kwargs)
-        irl_model = training_kwargs['irl_model']
-        policy = training_kwargs['policy']
-        reward_model_cfg = training_kwargs['reward_model_cfg']
+        irl_model = algo.irl_model
+        policy = algo.policy
 
         with rllab_logdir(algo=algo, dirname=log_dir):
             print("Training!")

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -501,7 +501,7 @@ def training_config(
         *,
         n_itr=1000,
         discount=0.99,
-        batch_size=500,
+        batch_size=5000,
         max_path_length=100,
         entropy_weight=0.01,
         step_size=0.01

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -44,6 +44,19 @@ from tensorflow.python import debug as tf_debug
 
 
 class DiscreteIRLPolicy(StochasticPolicy, Serializable):
+    """
+    This lets us wrap our PPO + old training code to almost fit into the
+    the IRLBatchPolOpt framework. Unfortunately, it currently conflates a few
+    things because of a bunch of shape issues between MuJoCo environments and
+    Atari environments.
+    - It has some of the responsibilities of the Sampler
+    - It has some of the responsibilities of the Policy
+    - It has some of the responsibilities of the RLAlgorithm
+
+    The good news is that the IRL code doesn't actually look at any of the
+    shapes, so we should be able to move back to the actual IRLBatchPolOpt
+    interface by breaking some things out.
+    """
     def __init__(
             self,
             name,
@@ -219,6 +232,8 @@ def cnn_net(x, actions=None, dout=1, **conv_kwargs):
 
 class AtariAIRL(AIRL):
     """
+    This actually fits the AIRL interface! Yay!
+
     Args:
         fusion (bool): Use trajectories from old iterations to train.
         state_only (bool): Fix the learned reward to only depend on state.
@@ -340,6 +355,12 @@ def make_irl_model(model_cfg, *, env_spec, expert_trajs):
 
 
 class IRLRunner(IRLTRPO):
+    """
+    This takes over the IRLTRPO code, to actually run IRL. Right now it has a
+    few issues...
+    [ ] It doesn't share the sample buffer between the discriminator and policy
+    [ ] It doesn't work on MuJoCo
+    """
     def __init__(self, *args, cmd_line_args=None, **kwargs):
         IRLTRPO.__init__(self, *args, **kwargs)
         self.cmd_line_args = cmd_line_args

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -50,8 +50,16 @@ class DiscreteIRLPolicy(StochasticPolicy, Serializable):
     things because of a bunch of shape issues between MuJoCo environments and
     Atari environments.
     - It has some of the responsibilities of the Sampler
+        if we finagle the input from VectorizedSampler into the right format
+        we can abandon this part, and have things be swappable out
     - It has some of the responsibilities of the Policy
-    - It has some of the responsibilities of the RLAlgorithm
+        that is correct and should stay
+    - It has some of the responsibilities of the RLAlgorithm (TRPO for instance)
+        we should figure out how to split that out of here
+        in particular, training.Learner already implements optimize_policy
+        which depends on a private _run_info buffer, that seems like we just
+        need to reshape and it should be good
+        -> this means that we implement PPOOptimizer
 
     The good news is that the IRL code doesn't actually look at any of the
     shapes, so we should be able to move back to the actual IRLBatchPolOpt

--- a/atari_irl/training.py
+++ b/atari_irl/training.py
@@ -202,8 +202,6 @@ class Learner:
         lrnow = self.lr(frac)
         cliprangenow = self.cliprange(frac)
 
-
-
         # Run the training steps for PPO
         mblossvals = train_steps(
             model=self.policy.model,

--- a/scripts/train_airl.py
+++ b/scripts/train_airl.py
@@ -21,7 +21,7 @@ def train_airl(args):
     with env_context_for_args(args) as context:
         logger.configure()
         reward, policy_params = irl.airl(
-            context.environments, ts, args.discount, args.irl_seed, logger.get_dir(),
+            context.environments, ts, args.irl_seed, logger.get_dir(),
             tf_cfg=tf_cfg,
             training_cfg={
                 'n_itr': args.n_iter,

--- a/tests/test_irl.py
+++ b/tests/test_irl.py
@@ -3,6 +3,8 @@ import tensorflow as tf
 import numpy as np
 import pickle
 
+from baselines.ppo2 import ppo2
+
 
 class TestAtariIRL:
     def test_sample_shape(self):
@@ -26,35 +28,88 @@ class TestAtariIRL:
                 T = len(sample['observations'])
                 print(f"\tFound trajectory of length {T}")
                 if not hasattr(sample['observations'], 'shape'):
-                    print("Time index is list, not numpy dimension")
+                    print("\tTime index is list, not numpy dimension")
                 assert np.array(sample['observations']).shape == (T, 84, 84, 4)
                 assert np.array(sample['actions']).shape == (T, 6)
 
+        def invert_ppo_sample_raveling(ppo_samples, num_envs=8):
+            return ppo_samples.reshape(
+                num_envs, ppo_samples.shape[0] // num_envs,
+                *ppo_samples.shape[1:]
+            ).swapaxes(1, 0)
+
+        def ppo_samples_to_trajectory_format(ppo_samples, num_envs=8):
+            OBS_IDX = 0
+            ACTS_IDX = 3
+            DONES_IDX = 2
+
+            obs = invert_ppo_sample_raveling(
+                ppo_samples[OBS_IDX], num_envs=num_envs
+            )
+            acts = invert_ppo_sample_raveling(
+                ppo_samples[ACTS_IDX], num_envs=num_envs
+            )
+            T = obs.shape[0]
+            observations = [[] for _ in range(num_envs)]
+            actions = [[] for _ in range(num_envs)]
+            assert acts.shape[0] == T
+            for t in range(T):
+                for i, (o, a) in enumerate(zip(obs[t], acts[t])):
+                    observations[i].append(o)
+                    actions[i].append(a)
+            trajectories = [{
+                'observations': np.array(observations[i]),
+                'actions': utils.one_hot(actions[i], 6)
+            } for i in range(num_envs)]
+            np.random.shuffle(trajectories)
+            return trajectories
+
+        def check_base_policy_sampler(algo, env_context):
+            print("Checking straightforward policy trajectory sampler")
+            policy_samples = policies.sample_trajectories(
+                model=algo.policy.learner.model,
+                environments=env_context.environments,
+                one_hot_code=True,
+                n_trajectories=10,
+                render=False
+            )
+            assert len(policy_samples) == 10
+            assert_trajectory_formatted(policy_samples)
+
+        def check_irl_discriminator_sampler(algo, env_context):
+            print("Checking discriminator sampler")
+            #env_context.environments.reset()
+            algo.start_worker()
+            irl_discriminator_samples = algo.obtain_samples(0)
+            assert_trajectory_formatted(irl_discriminator_samples)
+
+        def check_irl_ppo_policy_sampler(algo, env_context):
+            print("Checking IRL PPO policy sampler")
+            irl_policy_samples = algo.policy.learner.runner.run()
+            obs = irl_policy_samples[0]
+            # Test that our sample raveling inversion actually inverts the
+            # sf01 function applied by the ppo2 code
+            assert np.isclose(
+                ppo2.sf01(invert_ppo_sample_raveling(
+                    obs, env_context.environments.num_envs
+                )), obs
+            ).all()
+            assert_trajectory_formatted(ppo_samples_to_trajectory_format(
+                irl_policy_samples, num_envs=env_context.environments.num_envs
+            ))
 
         with utils.EnvironmentContext(
             env_name=env, n_envs=8, seed=0, **env_modifiers
         ) as env_context:
             with irl.IRLContext(config, seed=0) as irl_context:
-                algo = irl.IRLRunner(**irl.get_training_kwargs(
+                training_kwargs, _, _ = irl.get_training_kwargs(
                     venv=env_context.environments,
                     irl_context=irl_context,
-                    expert_trajectories=pickle.load(
-                        open('scripts/short_trajectories.pkl', 'rb')
-                    )
-                )[0])
-
-                policy_samples = policies.sample_trajectories(
-                    model=algo.policy.learner.model,
-                    environments=env_context.environments,
-                    one_hot_code=True,
-                    n_trajectories=10,
-                    render=False
+                    expert_trajectories=pickle.load(open('scripts/short_trajectories.pkl', 'rb')),
                 )
-                assert len(policy_samples) == 10
-                assert_trajectory_formatted(policy_samples)
-
-                env_context.environments.reset()
-                algo.start_worker()
-                irl_discriminator_samples = algo.obtain_samples(0)
-
-                assert_trajectory_formatted(irl_discriminator_samples)
+                print("Training arguments: ", training_kwargs)
+                algo = irl.IRLRunner(**training_kwargs)
+                check_base_policy_sampler(algo, env_context)
+                check_irl_discriminator_sampler(algo, env_context)
+                check_irl_ppo_policy_sampler(algo, env_context)
+                assert False

--- a/tests/test_irl.py
+++ b/tests/test_irl.py
@@ -1,0 +1,60 @@
+from atari_irl import irl, utils, environments, policies
+import tensorflow as tf
+import numpy as np
+import pickle
+
+
+class TestAtariIRL:
+    def test_sample_shape(self):
+        env = 'PongNoFrameskip-v4'
+        env_modifiers = environments.env_mapping[env]
+        env_modifiers = environments.one_hot_wrap_modifiers(env_modifiers)
+
+        config = tf.ConfigProto(
+            allow_soft_placement=True,
+            intra_op_parallelism_threads=8,
+            inter_op_parallelism_threads=8,
+            device_count={'GPU': 1},
+        )
+        config.gpu_options.allow_growth=True
+
+        def assert_trajectory_formatted(samples):
+            print(f"Found {len(samples)} trajectories")
+            for sample in samples:
+                assert 'observations' in sample
+                assert 'actions' in sample
+                T = len(sample['observations'])
+                print(f"\tFound trajectory of length {T}")
+                if not hasattr(sample['observations'], 'shape'):
+                    print("Time index is list, not numpy dimension")
+                assert np.array(sample['observations']).shape == (T, 84, 84, 4)
+                assert np.array(sample['actions']).shape == (T, 6)
+
+
+        with utils.EnvironmentContext(
+            env_name=env, n_envs=8, seed=0, **env_modifiers
+        ) as env_context:
+            with irl.IRLContext(config, seed=0) as irl_context:
+                algo = irl.IRLRunner(**irl.get_training_kwargs(
+                    venv=env_context.environments,
+                    irl_context=irl_context,
+                    expert_trajectories=pickle.load(
+                        open('scripts/short_trajectories.pkl', 'rb')
+                    )
+                )[0])
+
+                policy_samples = policies.sample_trajectories(
+                    model=algo.policy.learner.model,
+                    environments=env_context.environments,
+                    one_hot_code=True,
+                    n_trajectories=10,
+                    render=False
+                )
+                assert len(policy_samples) == 10
+                assert_trajectory_formatted(policy_samples)
+
+                env_context.environments.reset()
+                algo.start_worker()
+                irl_discriminator_samples = algo.obtain_samples(0)
+
+                assert_trajectory_formatted(irl_discriminator_samples)

--- a/tests/test_irl.py
+++ b/tests/test_irl.py
@@ -141,4 +141,36 @@ class TestAtariIRL:
                 # It shouldn't be super short
                 assert len(vectorized_samples[0]['actions']) > 100
 
-                assert False
+                def batch_reshape(single_traj_data):
+                    single_traj_data = np.asarray(single_traj_data)
+                    s = single_traj_data.shape
+                    return single_traj_data.reshape(s[0], 1, *s[1:])
+
+                def ppo_process_trajectory(traj):
+                    agent_info = traj['agent_infos']
+                    dones = np.zeros(agent_info['values'].shape)
+                    dones[-1] = 1
+                    algo.policy.baselines_venv.reset()
+                    algo.policy.learner.runner.dones = np.ones(1)
+                    return algo.policy.learner.runner.process_ppo_samples(
+                        # The easy stuff that we just observe
+                        batch_reshape(traj['observations']),
+                        batch_reshape(traj['rewards']),
+                        batch_reshape(traj['actions']).argmax(axis=1),
+                        # now the things from the agent info
+                        agent_info['values'], dones, agent_info['neglogpacs'],
+                        # and the annotations
+                        None, traj['env_infos']
+                    )
+
+                # These are very different because the policy is
+                # non-deterministic. This test is only checking that the
+                # shapes are right, and we need something more deterministic to
+                # determine that the return calculation is also correct
+                ppo_processed = ppo_process_trajectory(vectorized_samples[0])
+                ppo_generated = algo.policy.learner.runner.run()
+
+                # the indices before the states and episode infos
+                for i in range(6):
+                    print(i)
+                    assert ppo_processed[i][:128].shape == ppo_generated[i].shape


### PR DESCRIPTION
This adds more information to agent_info, so that we're actually following the interface the VectorizedSampler expects.

However, this isn't actually going to mean that we can use the VectorizedSampler class, because the PPO code unfortunately has a pretty close interaction between the number of environments and the ability to actually process a trajectory. This stops us from being able to confidently process a VectorizedSampler trajectory into something suitable for the PPO code.

In light of this, it makes the most sense to mutate the training.Runner class into a monster that follows the BatchSampler interface, but while saving the information we need in order use PPO.