### PR TITLE
Aaron/use ppo sampler

### DIFF
--- a/atari_irl/__init__.py
+++ b/atari_irl/__init__.py
@@ -1,1 +1,1 @@
-from . import utils, training, policies, environments, irl
+from . import utils, training, policies, environments, irl, sampling

--- a/atari_irl/environments.py
+++ b/atari_irl/environments.py
@@ -130,12 +130,17 @@ easy_env_modifiers = {
     ]
 }
 
+import functools
+# Episode Life causes us to not actually reset the environments, which means
+# that interleaving, and even running the normal sampler a bunch of times
+# will give us super short trajectories. Right now we set it to false, but
+# that's not an obviously correct way to handle the problem
 atari_modifiers = {
     'env_modifiers': [
         wrap_env_with_args(NoopResetEnv, noop_max=30),
         wrap_env_with_args(MaxAndSkipEnv, skip=4),
-        wrap_deepmind,
-        wrap_env_with_args(TimeLimitEnv, time_limit=5000)
+        functools.partial(wrap_deepmind, episode_life=False),
+        #wrap_env_with_args(TimeLimitEnv, time_limit=5000)
     ],
     'vec_env_modifiers': [
         wrap_env_with_args(VecFrameStack, nstack=4)

--- a/atari_irl/environments.py
+++ b/atari_irl/environments.py
@@ -122,7 +122,7 @@ class VecOneHotEncodingEnv(VecEnvWrapper):
 
 easy_env_modifiers = {
     'env_modifiers': [
-        wrap_deepmind,
+        lambda env: wrap_deepmind(env, frame_stack=False),
         wrap_env_with_args(TimeLimitEnv, time_limit=5000)
     ],
     'vec_env_modifiers': [

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -508,10 +508,17 @@ class PPOBatchSampler(BaseSampler):
     def __init__(self, algo):
         super(PPOBatchSampler, self).__init__(algo)
         assert isinstance(algo, DiscreteIRLPolicy)
-        self._itr = 0
+        self.cur_sample = None
+
+    def start_worker(self):
+        pass
+
+    def shutdown_worker(self):
+        pass
 
     def obtain_samples(self, itr):
-        sample = self.algo.policy.runner.sample()
+        self.cur_sample = self.algo.policy.runner.sample()
+        return self.cur_sample.to_trajectories()
 
     def process_samples(self, itr, paths):
         return self.cur_sample

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -113,14 +113,6 @@ class DiscreteIRLPolicy(StochasticPolicy, Serializable):
         )
 
     def get_actions(self, observations):
-        """
-
-        Args:
-            observations:
-
-        Returns:
-
-        """
         N = observations.shape[0]
         batch_size = self.act_model.X.shape[0].value
 
@@ -211,9 +203,6 @@ class DiscreteIRLPolicy(StochasticPolicy, Serializable):
             venv.render()
 
     def train_step(self):
-        #for i in range(30):
-        #    if i % 10 == 0:
-        #        print(i, safemean([epinfo['r'] for epinfo in self.learner._epinfobuf]))
         self.learner.step()
         self.learner.print_log(self.learner)
 

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -430,6 +430,10 @@ class IRLRunner(IRLTRPO):
         return paths
 
     @overrides
+    def process_samples(self, itr, paths):
+        return {'paths': paths}
+
+    @overrides
     def optimize_policy(self, itr, samples_data):
         samples_data = self.policy.learner.runner.process_trajectory(
             samples_data['paths'][0]

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -558,7 +558,7 @@ def get_training_kwargs(
     training_kwargs.update(training_cfg)
     training_kwargs.update(ablation_training_modifiers)
 
-    return training_kwargs
+    return training_kwargs, policy_cfg, reward_model_cfg
 
 
 # Heavily based on implementation in https://github.com/HumanCompatibleAI/population-irl/blob/master/pirl/irl/airl.py
@@ -569,7 +569,7 @@ def airl(
         ablation='normal'
 ):
     with IRLContext(tf_cfg, seed=seed) as irl_context:
-        training_kwargs = get_training_kwargs(
+        training_kwargs, _, reward_model_cfg = get_training_kwargs(
             venv=venv,
             irl_context=irl_context,
             reward_model_cfg=reward_model_cfg,
@@ -580,9 +580,8 @@ def airl(
         )
         print("Training arguments: ", training_kwargs)
         algo = IRLRunner(**training_kwargs)
-        irl_model = training_kwargs['irl_model']
-        policy = training_kwargs['policy']
-        reward_model_cfg = training_kwargs['reward_model_cfg']
+        irl_model = algo.irl_model
+        policy = algo.policy
 
         with rllab_logdir(algo=algo, dirname=log_dir):
             print("Training!")

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -506,6 +506,8 @@ class IRLContext:
 
 
 class PPOBatchSampler(BaseSampler):
+    # If you want to use the baselines PPO sampler as a sampler for the
+    # airl interfaced code, use this.
     def __init__(self, algo):
         super(PPOBatchSampler, self).__init__(algo)
         assert isinstance(algo.policy, DiscreteIRLPolicy)
@@ -532,6 +534,8 @@ class PPOBatchSampler(BaseSampler):
 
 
 class FullTrajectorySampler(VectorizedSampler):
+    # If you want to use the RLLab sampling code with a baselines-interfaced
+    # policy, use this.
     @overrides
     def process_samples(self, itr, paths):
         """

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -501,7 +501,7 @@ def training_config(
         *,
         n_itr=1000,
         discount=0.99,
-        batch_size=500,
+        batch_size=5000,
         max_path_length=100,
         entropy_weight=0.01,
         step_size=0.01

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -436,6 +436,7 @@ class IRLRunner(IRLTRPO):
         self.policy.learner._itr = itr
         self.policy.learner._run_info = samples_data
         self.policy.learner.optimize_policy(itr)
+        self.policy.learner.print_log(self.policy.learner)
 
     def train(self):
         sess = tf.get_default_session()
@@ -655,9 +656,10 @@ def airl(
             ablation=ablation,
         )
         print("Training arguments: ", training_kwargs)
+        training_kwargs['sampler_args'] = {}
         algo = IRLRunner(
             **training_kwargs,
-            sampler_cls=FullTrajectorySampler
+            sampler_cls=PPOBatchSampler,
         )
         irl_model = algo.irl_model
         policy = algo.policy

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -44,6 +44,19 @@ from tensorflow.python import debug as tf_debug
 
 
 class DiscreteIRLPolicy(StochasticPolicy, Serializable):
+    """
+    This lets us wrap our PPO + old training code to almost fit into the
+    the IRLBatchPolOpt framework. Unfortunately, it currently conflates a few
+    things because of a bunch of shape issues between MuJoCo environments and
+    Atari environments.
+    - It has some of the responsibilities of the Sampler
+    - It has some of the responsibilities of the Policy
+    - It has some of the responsibilities of the RLAlgorithm
+
+    The good news is that the IRL code doesn't actually look at any of the
+    shapes, so we should be able to move back to the actual IRLBatchPolOpt
+    interface by breaking some things out.
+    """
     def __init__(
             self,
             name,
@@ -219,6 +232,8 @@ def cnn_net(x, actions=None, dout=1, **conv_kwargs):
 
 class AtariAIRL(AIRL):
     """
+    This actually fits the AIRL interface! Yay!
+
     Args:
         fusion (bool): Use trajectories from old iterations to train.
         state_only (bool): Fix the learned reward to only depend on state.
@@ -340,6 +355,12 @@ def make_irl_model(model_cfg, *, env_spec, expert_trajs):
 
 
 class IRLRunner(IRLTRPO):
+    """
+    This takes over the IRLTRPO code, to actually run IRL. Right now it has a
+    few issues...
+    [ ] It doesn't share the sample buffer between the discriminator and policy
+    [ ] It doesn't work on MuJoCo
+    """
     def __init__(self, *args, cmd_line_args=None, **kwargs):
         IRLTRPO.__init__(self, *args, **kwargs)
         self.cmd_line_args = cmd_line_args

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -519,7 +519,9 @@ class PPOBatchSampler(BaseSampler):
 
     def obtain_samples(self, itr):
         self.cur_sample = self.algo.policy.learner.runner.sample()
-        return self.cur_sample.to_trajectories()
+        samples = self.cur_sample.to_trajectories()
+        self.algo.irl_model._insert_next_state(samples)
+        return samples
 
     def process_samples(self, itr, paths):
         ppo_batch = self.cur_sample.to_ppo_batch()

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -429,7 +429,13 @@ class IRLRunner(IRLTRPO):
         logger.record_tabular("NumTimesteps", sum([len(p['rewards']) for p in paths]))
         return paths
 
+    @overrides
     def optimize_policy(self, itr, samples_data):
+        #trajectories = samples_data['samples_data']
+        self.policy.learner.runner.process_trajectory(
+            samples_data['paths'][0]
+        )
+        import pdb; pdb.set_trace()
         self.policy.train_step()
 
     def train(self):
@@ -446,19 +452,13 @@ class IRLRunner(IRLTRPO):
         for itr in range(self.start_itr, self.n_itr):
             itr_start_time = time.time()
             with logger.prefix('itr #%d | ' % itr):
-                if not self.skip_discriminator:
-                    logger.log("Obtaining samples...")
-                    paths = self.obtain_samples(itr)
+                logger.log("Obtaining samples...")
+                paths = self.obtain_samples(itr)
 
-                    logger.log("Processing samples...")
-                    paths = self.compute_irl(paths, itr=itr)
-                    returns.append(self.log_avg_returns(paths))
-                    samples_data = self.process_samples(itr, paths)
-
-                    logger.log("Logging diagnostics...")
-                    self.log_diagnostics(paths)
-                else:
-                    samples_data=None
+                logger.log("Processing samples...")
+                paths = self.compute_irl(paths, itr=itr)
+                returns.append(self.log_avg_returns(paths))
+                samples_data = self.process_samples(itr, paths)
 
                 logger.log("Optimizing policy...")
                 self.optimize_policy(itr, samples_data)

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -50,8 +50,16 @@ class DiscreteIRLPolicy(StochasticPolicy, Serializable):
     things because of a bunch of shape issues between MuJoCo environments and
     Atari environments.
     - It has some of the responsibilities of the Sampler
+        if we finagle the input from VectorizedSampler into the right format
+        we can abandon this part, and have things be swappable out
     - It has some of the responsibilities of the Policy
-    - It has some of the responsibilities of the RLAlgorithm
+        that is correct and should stay
+    - It has some of the responsibilities of the RLAlgorithm (TRPO for instance)
+        we should figure out how to split that out of here
+        in particular, training.Learner already implements optimize_policy
+        which depends on a private _run_info buffer, that seems like we just
+        need to reshape and it should be good
+        -> this means that we implement PPOOptimizer
 
     The good news is that the IRL code doesn't actually look at any of the
     shapes, so we should be able to move back to the actual IRLBatchPolOpt

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -435,6 +435,7 @@ class IRLRunner(IRLTRPO):
 
     @overrides
     def optimize_policy(self, itr, samples_data):
+        print(f"Score in training range: {sum(samples_data['paths'][0]['rewards'][:512])}")
         samples_data = self.policy.learner.runner.process_trajectory(
             samples_data['paths'][0]
         )

--- a/atari_irl/sampling.py
+++ b/atari_irl/sampling.py
@@ -1,0 +1,159 @@
+import numpy as np
+from . import utils
+from collections import namedtuple
+
+
+# This is a PPO Batch that the OpenAI Baselines PPO code uses as its underlying
+# representation
+PPOBatch = namedtuple('PPOBatch', [
+    'obs', 'returns', 'masks', 'actions', 'values', 'neglogpacs', 'states',
+    'epinfos'
+])
+PPOBatch.train_args = lambda self: (
+    self.obs, self.returns, self.masks, self.actions, self.values, self.neglogpacs
+)
+
+
+# This is a full trajectory, using the interface defines by RLLab and the
+# AIRL library
+class Trajectory:
+    def __init__(self):
+        self.observations = []
+        self.actions = []
+        self.rewards = []
+        self.env_infos = {
+            'dones': []
+        }
+        self.agent_infos = {
+            'values': [],
+            'neglogpacs': [],
+        }
+        self.is_finalized = False
+
+    def __getitem__(self, key):
+        return {
+            'observations': self.observations,
+            'actions': self.actions,
+            'rewards': self.rewards
+        }[key]
+
+    def __contains__(self, key):
+        return key in {'observations', 'actions', 'rewards'}
+
+    def add_ppo_batch_data(self, obs, act, rew, done, value, neglogpac):
+        self.observations.append(obs)
+        self.actions.append(act)
+        self.rewards.append(rew)
+        self.env_infos['dones'].append(done)
+        self.agent_infos['values'].append(value)
+        self.agent_infos['neglogpacs'].append(neglogpac)
+
+    def finalize(self):
+        assert not self.is_finalized
+        self.observations = np.asarray(self.observations)
+        self.actions = utils.one_hot(self.actions, 6)
+        self.rewards = np.asarray(self.rewards)
+        self.is_finalized = True
+
+
+class Trajectories:
+    def __init__(self, trajectories, ppo_sample=None):
+        self.trajectories = trajectories
+        self.ppo_sample = ppo_sample
+
+    def __get__(self, idx):
+        return self.trajectories[idx]
+
+    def to_ppo_sample(self) -> 'PPOSample':
+        # This is kind of hacky, and ideally we would roundtrip it, but doing
+        # a proper roundtrip is going to be slower than doing this
+        if self.ppo_sample is not None:
+            return self.ppo_sample
+
+
+class PPOSample:
+    """
+    A trajectory slice generated according to the PPO batch logic.
+
+    This can be transformed into both a PPOBatch (for PPO training), and a
+    Trajectories object which doesn't actually correspond to full trajectories,
+    (for the discriminator training)
+    """
+    def __init__(
+            self, obs, rewards, actions, values, dones, neglogpacs, states,
+            epinfos, runner
+    ):
+        self.obs = obs
+        self.rewards = rewards
+        self.actions = actions
+        self.values = values
+        self.dones = dones
+        self.neglogpacs = neglogpacs
+        self.states = states
+        self.epinfos = epinfos
+        self.runner = runner
+
+    def to_ppo_batch(self) -> PPOBatch:
+        return PPOBatch(*self.runner.process_ppo_samples(
+            self.obs, self.rewards, self.actions, self.values, self.dones,
+            self.neglogpacs, self.states, self.epinfos
+        ))
+
+    def to_trajectories(self) -> 'Trajectories':
+        T = len(self.obs)
+        num_envs = self.obs[0].shape[0]
+        buffer = [Trajectory() for _ in range(num_envs)]
+
+        for t in range(T):
+            for e in range(num_envs):
+                buffer[e].add_ppo_batch_data(
+                    self.obs[t][e],
+                    self.actions[t][e],
+                    self.rewards[t][e],
+                    self.dones[t][e],
+                    self.values[t][e],
+                    self.neglogpacs[t][e],
+                )
+
+        for traj in buffer:
+            traj.finalize()
+
+        return Trajectories(buffer, self)
+
+
+# This code isn't actually used right now, but it is tested so I'm keeping it
+# around
+def invert_ppo_sample_raveling(ppo_samples, num_envs=8):
+    return ppo_samples.reshape(
+        num_envs, ppo_samples.shape[0] // num_envs,
+        *ppo_samples.shape[1:]
+    ).swapaxes(1, 0)
+
+
+def ppo_samples_to_trajectory_format(ppo_samples, num_envs=8):
+    OBS_IDX = 0
+    ACTS_IDX = 3
+
+    obs = invert_ppo_sample_raveling(ppo_samples[OBS_IDX], num_envs=num_envs)
+    acts = invert_ppo_sample_raveling(ppo_samples[ACTS_IDX], num_envs=num_envs)
+
+    T = obs.shape[0]
+    observations = [[] for _ in range(num_envs)]
+    actions = [[] for _ in range(num_envs)]
+
+    assert acts.shape[0] == T
+    for t in range(T):
+        for i, (o, a) in enumerate(zip(obs[t], acts[t])):
+            observations[i].append(o)
+            actions[i].append(a)
+
+    trajectories = [
+        {
+            'observations': np.array(observations[i]),
+            'actions': utils.one_hot(actions[i], 6)
+        }
+        for i in range(num_envs)
+    ]
+    np.random.shuffle(trajectories)
+
+    return trajectories

--- a/atari_irl/sampling.py
+++ b/atari_irl/sampling.py
@@ -1,4 +1,5 @@
 import numpy as np
+import tensorflow as tf
 from . import utils
 from collections import namedtuple
 

--- a/atari_irl/sampling.py
+++ b/atari_irl/sampling.py
@@ -31,24 +31,22 @@ class Trajectory:
         }
         self.is_finalized = False
 
+        self.added_data = {}
+
     def __getitem__(self, key):
-        return {
-            'observations': self.observations,
-            'actions': self.actions,
-            'rewards': self.rewards,
-            'agent_infos': self.agent_infos
-        }[key]
+        if hasattr(self, key):
+            return getattr(self, key)
+        else:
+            return self.added_data[key]
 
     def __setitem__(self, key, value):
-        if key == 'observations':
-            self.observations = value
-        elif key == 'actions':
-            self.actions = value
-        elif key == 'rewards':
-            self.rewards = value
+        if hasattr(self, key):
+            setattr(self, key, value)
+        else:
+            self.added_data[key] = value
 
     def __contains__(self, key):
-        return key in {'observations', 'actions', 'rewards'}
+        return hasattr(self, key) or key in self.added_data
 
     def add_ppo_batch_data(self, obs, act, rew, done, value, neglogpac, prob):
         self.observations.append(obs)

--- a/atari_irl/sampling.py
+++ b/atari_irl/sampling.py
@@ -103,7 +103,7 @@ class PPOSample:
         self.values = np.asarray(values)
         self.dones = np.asarray(dones)
         self.neglogpacs = np.asarray(neglogpacs)
-        self.states = np.asarray(states)
+        self.states = states
         self.epinfos = epinfos
         self.runner = runner
 

--- a/atari_irl/sampling.py
+++ b/atari_irl/sampling.py
@@ -27,6 +27,7 @@ class Trajectory:
         self.agent_infos = {
             'values': [],
             'neglogpacs': [],
+            'prob': []
         }
         self.is_finalized = False
 
@@ -34,8 +35,17 @@ class Trajectory:
         return {
             'observations': self.observations,
             'actions': self.actions,
-            'rewards': self.rewards
+            'rewards': self.rewards,
+            'agent_infos': self.agent_infos
         }[key]
+
+    def __setitem__(self, key, value):
+        if key == 'observations':
+            self.observations = value
+        elif key == 'actions':
+            self.actions = value
+        elif key == 'rewards':
+            self.rewards = value
 
     def __contains__(self, key):
         return key in {'observations', 'actions', 'rewards'}
@@ -61,8 +71,11 @@ class Trajectories:
         self.trajectories = trajectories
         self.ppo_sample = ppo_sample
 
-    def __get__(self, idx):
+    def __getitem__(self, idx):
         return self.trajectories[idx]
+
+    def __len__(self):
+        return len(self.trajectories)
 
     def to_ppo_sample(self) -> 'PPOSample':
         # This is kind of hacky, and ideally we would roundtrip it, but doing

--- a/atari_irl/training.py
+++ b/atari_irl/training.py
@@ -202,8 +202,6 @@ class Learner:
         lrnow = self.lr(frac)
         cliprangenow = self.cliprange(frac)
 
-
-
         # Run the training steps for PPO
         mblossvals = train_steps(
             model=self.policy.model,

--- a/atari_irl/training.py
+++ b/atari_irl/training.py
@@ -7,7 +7,7 @@ from baselines.ppo2 import ppo2
 
 from rllab.sampler.base import BaseSampler
 
-from . import policies
+from . import policies, utils
 
 from collections import deque, namedtuple
 import time
@@ -164,8 +164,38 @@ class Runner(ppo2.AbstractEnvRunner, BaseSampler):
         self.lam = lam
         self.gamma = gamma
 
-    def set_algo(self, algo):
-        self.algo = algo
+    @staticmethod
+    def invert_ppo_sample_raveling(ppo_samples, num_envs=8):
+        return ppo_samples.reshape(
+            num_envs, ppo_samples.shape[0] // num_envs,
+            *ppo_samples.shape[1:]
+        ).swapaxes(1, 0)
+
+    @staticmethod
+    def ppo_samples_to_trajectory_format(ppo_samples, num_envs=8):
+        OBS_IDX = 0
+        ACTS_IDX = 3
+
+        obs = Runner.invert_ppo_sample_raveling(
+            ppo_samples[OBS_IDX], num_envs=num_envs
+        )
+        acts = Runner.invert_ppo_sample_raveling(
+            ppo_samples[ACTS_IDX], num_envs=num_envs
+        )
+        T = obs.shape[0]
+        observations = [[] for _ in range(num_envs)]
+        actions = [[] for _ in range(num_envs)]
+        assert acts.shape[0] == T
+        for t in range(T):
+            for i, (o, a) in enumerate(zip(obs[t], acts[t])):
+                observations[i].append(o)
+                actions[i].append(a)
+        trajectories = [{
+                            'observations': np.array(observations[i]),
+                            'actions': utils.one_hot(actions[i], 6)
+                        } for i in range(num_envs)]
+        np.random.shuffle(trajectories)
+        return trajectories
 
     def sample(self):
         mb_obs, mb_rewards, mb_actions, mb_values, mb_dones, mb_neglogpacs = [],[],[],[],[],[]

--- a/atari_irl/training.py
+++ b/atari_irl/training.py
@@ -198,7 +198,6 @@ class Runner(ppo2.AbstractEnvRunner, BaseSampler):
         mb_values = np.asarray(mb_values, dtype=np.float32)
         mb_neglogpacs = np.asarray(mb_neglogpacs, dtype=np.float32)
         mb_dones = np.asarray(mb_dones, dtype=np.bool)
-        import pdb; pdb.set_trace()
         last_values = self.model.value(self.obs, self.states, self.dones)
         #discount/bootstrap off value fn
         mb_returns = np.zeros_like(mb_rewards)
@@ -227,6 +226,8 @@ class Runner(ppo2.AbstractEnvRunner, BaseSampler):
         self.state = None
         self.obs[:] = traj['observations'][-1]
         self.dones = np.ones(self.env.num_envs)
+        dones = np.zeros(agent_info['values'].shape)
+        dones[-1] = 1
         # This is actually kind of weird w/r/t to the PPO code, because the
         # batch length is so much longer. Maybe this will work? But if PPO
         # ablations don't crash, but fail to learn this is probably why.
@@ -236,7 +237,7 @@ class Runner(ppo2.AbstractEnvRunner, BaseSampler):
             np.hstack([batch_reshape(traj['rewards']) for _ in range(8)]),
             batch_reshape(traj['actions']).argmax(axis=1),
             # now the things from the agent info
-            agent_info['values'], self.dones, agent_info['neglogpacs'],
+            agent_info['values'], dones, agent_info['neglogpacs'],
             # and the annotations
             None, traj['env_infos']
         )

--- a/scripts/arguments.py
+++ b/scripts/arguments.py
@@ -36,6 +36,11 @@ def add_expert_args(parser):
         help='file for the expert policy',
         default='experts/new_expert'
     )
+    parser.add_argument(
+        '--nsteps',
+        help='length of time in a minibatch step',
+        type=int, default=128
+    )
 
 
 def add_irl_args(parser):

--- a/scripts/run_irl_policy.py
+++ b/scripts/run_irl_policy.py
@@ -13,7 +13,7 @@ def run_irl_policy(args):
             envs = TfEnv(envs)
 
             policy = irl.make_irl_policy(
-                irl.policy_config(args),
+                irl.policy_config(),
                 envs=envs,
                 sess=tf.get_default_session()
             )

--- a/scripts/train_airl.py
+++ b/scripts/train_airl.py
@@ -21,7 +21,7 @@ def train_airl(args):
     with env_context_for_args(args) as context:
         logger.configure()
         reward, policy_params = irl.airl(
-            context.environments, ts, args.discount, args.irl_seed, logger.get_dir(),
+            context.environments, ts, args.irl_seed, logger.get_dir(),
             tf_cfg=tf_cfg,
             training_cfg={
                 'n_itr': args.n_iter,

--- a/scripts/train_expert.py
+++ b/scripts/train_expert.py
@@ -15,7 +15,7 @@ def train_expert(args):
                 context.environments,
                 total_timesteps=args.num_timesteps,
                 vf_coef=0.5, ent_coef=0.01,
-                nsteps=128, noptepochs=4, nminibatches=4,
+                nsteps=args.nsteps, noptepochs=4, nminibatches=4,
                 gamma=0.99, lam=0.95,
                 lr=lambda alpha: alpha * 2.5e-4,
                 cliprange=lambda alpha: alpha * 0.1

--- a/tests/test_irl.py
+++ b/tests/test_irl.py
@@ -3,6 +3,8 @@ import tensorflow as tf
 import numpy as np
 import pickle
 
+from baselines.ppo2 import ppo2
+
 
 class TestAtariIRL:
     def test_sample_shape(self):
@@ -26,35 +28,88 @@ class TestAtariIRL:
                 T = len(sample['observations'])
                 print(f"\tFound trajectory of length {T}")
                 if not hasattr(sample['observations'], 'shape'):
-                    print("Time index is list, not numpy dimension")
+                    print("\tTime index is list, not numpy dimension")
                 assert np.array(sample['observations']).shape == (T, 84, 84, 4)
                 assert np.array(sample['actions']).shape == (T, 6)
 
+        def invert_ppo_sample_raveling(ppo_samples, num_envs=8):
+            return ppo_samples.reshape(
+                num_envs, ppo_samples.shape[0] // num_envs,
+                *ppo_samples.shape[1:]
+            ).swapaxes(1, 0)
+
+        def ppo_samples_to_trajectory_format(ppo_samples, num_envs=8):
+            OBS_IDX = 0
+            ACTS_IDX = 3
+            DONES_IDX = 2
+
+            obs = invert_ppo_sample_raveling(
+                ppo_samples[OBS_IDX], num_envs=num_envs
+            )
+            acts = invert_ppo_sample_raveling(
+                ppo_samples[ACTS_IDX], num_envs=num_envs
+            )
+            T = obs.shape[0]
+            observations = [[] for _ in range(num_envs)]
+            actions = [[] for _ in range(num_envs)]
+            assert acts.shape[0] == T
+            for t in range(T):
+                for i, (o, a) in enumerate(zip(obs[t], acts[t])):
+                    observations[i].append(o)
+                    actions[i].append(a)
+            trajectories = [{
+                'observations': np.array(observations[i]),
+                'actions': utils.one_hot(actions[i], 6)
+            } for i in range(num_envs)]
+            np.random.shuffle(trajectories)
+            return trajectories
+
+        def check_base_policy_sampler(algo, env_context):
+            print("Checking straightforward policy trajectory sampler")
+            policy_samples = policies.sample_trajectories(
+                model=algo.policy.learner.model,
+                environments=env_context.environments,
+                one_hot_code=True,
+                n_trajectories=10,
+                render=False
+            )
+            assert len(policy_samples) == 10
+            assert_trajectory_formatted(policy_samples)
+
+        def check_irl_discriminator_sampler(algo, env_context):
+            print("Checking discriminator sampler")
+            #env_context.environments.reset()
+            algo.start_worker()
+            irl_discriminator_samples = algo.obtain_samples(0)
+            assert_trajectory_formatted(irl_discriminator_samples)
+
+        def check_irl_ppo_policy_sampler(algo, env_context):
+            print("Checking IRL PPO policy sampler")
+            irl_policy_samples = algo.policy.learner.runner.run()
+            obs = irl_policy_samples[0]
+            # Test that our sample raveling inversion actually inverts the
+            # sf01 function applied by the ppo2 code
+            assert np.isclose(
+                ppo2.sf01(invert_ppo_sample_raveling(
+                    obs, env_context.environments.num_envs
+                )), obs
+            ).all()
+            assert_trajectory_formatted(ppo_samples_to_trajectory_format(
+                irl_policy_samples, num_envs=env_context.environments.num_envs
+            ))
 
         with utils.EnvironmentContext(
             env_name=env, n_envs=8, seed=0, **env_modifiers
         ) as env_context:
             with irl.IRLContext(config, seed=0) as irl_context:
-                algo = irl.IRLRunner(**irl.get_training_kwargs(
+                training_kwargs, _, _ = irl.get_training_kwargs(
                     venv=env_context.environments,
                     irl_context=irl_context,
-                    expert_trajectories=pickle.load(
-                        open('scripts/short_trajectories.pkl', 'rb')
-                    )
-                )[0])
-
-                policy_samples = policies.sample_trajectories(
-                    model=algo.policy.learner.model,
-                    environments=env_context.environments,
-                    one_hot_code=True,
-                    n_trajectories=10,
-                    render=False
+                    expert_trajectories=pickle.load(open('scripts/short_trajectories.pkl', 'rb')),
                 )
-                assert len(policy_samples) == 10
-                assert_trajectory_formatted(policy_samples)
-
-                env_context.environments.reset()
-                algo.start_worker()
-                irl_discriminator_samples = algo.obtain_samples(0)
-
-                assert_trajectory_formatted(irl_discriminator_samples)
+                print("Training arguments: ", training_kwargs)
+                algo = irl.IRLRunner(**training_kwargs)
+                check_base_policy_sampler(algo, env_context)
+                check_irl_discriminator_sampler(algo, env_context)
+                check_irl_ppo_policy_sampler(algo, env_context)
+                assert False

--- a/tests/test_irl.py
+++ b/tests/test_irl.py
@@ -141,33 +141,13 @@ class TestAtariIRL:
                 # It shouldn't be super short
                 assert len(vectorized_samples[0]['actions']) > 100
 
-                def batch_reshape(single_traj_data):
-                    single_traj_data = np.asarray(single_traj_data)
-                    s = single_traj_data.shape
-                    return single_traj_data.reshape(s[0], 1, *s[1:])
-
-                def ppo_process_trajectory(traj):
-                    agent_info = traj['agent_infos']
-                    dones = np.zeros(agent_info['values'].shape)
-                    dones[-1] = 1
-                    algo.policy.baselines_venv.reset()
-                    algo.policy.learner.runner.dones = np.ones(1)
-                    return algo.policy.learner.runner.process_ppo_samples(
-                        # The easy stuff that we just observe
-                        batch_reshape(traj['observations']),
-                        batch_reshape(traj['rewards']),
-                        batch_reshape(traj['actions']).argmax(axis=1),
-                        # now the things from the agent info
-                        agent_info['values'], dones, agent_info['neglogpacs'],
-                        # and the annotations
-                        None, traj['env_infos']
-                    )
-
                 # These are very different because the policy is
                 # non-deterministic. This test is only checking that the
                 # shapes are right, and we need something more deterministic to
                 # determine that the return calculation is also correct
-                ppo_processed = ppo_process_trajectory(vectorized_samples[0])
+                ppo_processed = algo.policy.learner.runner.process_trajectory(
+                    vectorized_samples[0]
+                )
                 ppo_generated = algo.policy.learner.runner.run()
 
                 # the indices before the states and episode infos

--- a/tests/test_irl.py
+++ b/tests/test_irl.py
@@ -1,0 +1,60 @@
+from atari_irl import irl, utils, environments, policies
+import tensorflow as tf
+import numpy as np
+import pickle
+
+
+class TestAtariIRL:
+    def test_sample_shape(self):
+        env = 'PongNoFrameskip-v4'
+        env_modifiers = environments.env_mapping[env]
+        env_modifiers = environments.one_hot_wrap_modifiers(env_modifiers)
+
+        config = tf.ConfigProto(
+            allow_soft_placement=True,
+            intra_op_parallelism_threads=8,
+            inter_op_parallelism_threads=8,
+            device_count={'GPU': 1},
+        )
+        config.gpu_options.allow_growth=True
+
+        def assert_trajectory_formatted(samples):
+            print(f"Found {len(samples)} trajectories")
+            for sample in samples:
+                assert 'observations' in sample
+                assert 'actions' in sample
+                T = len(sample['observations'])
+                print(f"\tFound trajectory of length {T}")
+                if not hasattr(sample['observations'], 'shape'):
+                    print("Time index is list, not numpy dimension")
+                assert np.array(sample['observations']).shape == (T, 84, 84, 4)
+                assert np.array(sample['actions']).shape == (T, 6)
+
+
+        with utils.EnvironmentContext(
+            env_name=env, n_envs=8, seed=0, **env_modifiers
+        ) as env_context:
+            with irl.IRLContext(config, seed=0) as irl_context:
+                algo = irl.IRLRunner(**irl.get_training_kwargs(
+                    venv=env_context.environments,
+                    irl_context=irl_context,
+                    expert_trajectories=pickle.load(
+                        open('scripts/short_trajectories.pkl', 'rb')
+                    )
+                )[0])
+
+                policy_samples = policies.sample_trajectories(
+                    model=algo.policy.learner.model,
+                    environments=env_context.environments,
+                    one_hot_code=True,
+                    n_trajectories=10,
+                    render=False
+                )
+                assert len(policy_samples) == 10
+                assert_trajectory_formatted(policy_samples)
+
+                env_context.environments.reset()
+                algo.start_worker()
+                irl_discriminator_samples = algo.obtain_samples(0)
+
+                assert_trajectory_formatted(irl_discriminator_samples)

--- a/tests/test_irl.py
+++ b/tests/test_irl.py
@@ -141,4 +141,36 @@ class TestAtariIRL:
                 # It shouldn't be super short
                 assert len(vectorized_samples[0]['actions']) > 100
 
-                assert False
+                def batch_reshape(single_traj_data):
+                    single_traj_data = np.asarray(single_traj_data)
+                    s = single_traj_data.shape
+                    return single_traj_data.reshape(s[0], 1, *s[1:])
+
+                def ppo_process_trajectory(traj):
+                    agent_info = traj['agent_infos']
+                    dones = np.zeros(agent_info['values'].shape)
+                    dones[-1] = 1
+                    algo.policy.baselines_venv.reset()
+                    algo.policy.learner.runner.dones = np.ones(1)
+                    return algo.policy.learner.runner.process_ppo_samples(
+                        # The easy stuff that we just observe
+                        batch_reshape(traj['observations']),
+                        batch_reshape(traj['rewards']),
+                        batch_reshape(traj['actions']).argmax(axis=1),
+                        # now the things from the agent info
+                        agent_info['values'], dones, agent_info['neglogpacs'],
+                        # and the annotations
+                        None, traj['env_infos']
+                    )
+
+                # These are very different because the policy is
+                # non-deterministic. This test is only checking that the
+                # shapes are right, and we need something more deterministic to
+                # determine that the return calculation is also correct
+                ppo_processed = ppo_process_trajectory(vectorized_samples[0])
+                ppo_generated = algo.policy.learner.runner.run()
+
+                # the indices before the states and episode infos
+                for i in range(6):
+                    print(i)
+                    assert ppo_processed[i][:128].shape == ppo_generated[i].shape


### PR DESCRIPTION
Use the PPO sampler so that we can use good PPO hyperparameters. This passes the ablation check of being able to learn an expert policy for Pong if we don't train the discriminator or override the rewards with the discriminator rewards.