### PR TITLE
Aaron/better sampling

### DIFF
--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -796,6 +796,11 @@ class IRLRunner(IRLTRPO):
 
                 if not self.skip_policy_update:
                     logger.log("Optimizing policy...")
+                    # Another issue is that the expert trajectories start from
+                    # a particular set of random seeds, and that controls how
+                    # the resets happen. This means that the difference between
+                    # environment seeds might be enough to make the
+                    # discriminator's job easy.
                     self.optimize_policy(itr, samples_data)
 
                 logger.record_tabular(

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -783,6 +783,12 @@ class IRLRunner(IRLTRPO):
 
                 if not self.skip_discriminator:
                     logger.log("Optimizing discriminator...")
+                    # The fact that we're not using the reward labels from here
+                    # means that the policy optimization is effectively getting
+                    # an off-by-one issue. I'm not sure that this would fix the
+                    # issues that we're seeing, but it's definitely different
+                    # from the original algorithm and so we should try fixing
+                    # it anyway.
                     paths = self.compute_irl(samples, itr=itr)
 
                 logger.log("Processing samples...")

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -808,8 +808,6 @@ class IRLRunner(IRLTRPO):
                 returns.append(self.log_avg_returns(paths))
                 samples_data = self.process_samples(itr, paths)
 
-                import pdb; pdb.set_trace()
-
                 if not self.skip_policy_update:
                     logger.log("Optimizing policy...")
                     self.optimize_policy(itr, samples_data)

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -432,6 +432,7 @@ class AtariAIRL(AIRL):
             if self.drop_framestack:
                 obs_batch = obs_batch[:, :, :, -1:]
                 nobs_batch = nobs_batch[:, :, :, -1:]
+
             feed_dict = {
                 self.act_t: act_batch,
                 self.obs_t: obs_batch,
@@ -689,7 +690,9 @@ def get_training_kwargs(
         ablation=ablation,
         sampler_args=dict(
             baselines_venv=baselines_venv,
-            nsteps=nsteps
+            nsteps=nsteps,
+            gamma=0.99,
+            lam=0.95
         ),
         optimizer_args=dict(
             batching_config=batching_config,

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -61,10 +61,6 @@ class DiscreteIRLPolicy(StochasticPolicy, Serializable):
             init_location=init_location
         )
 
-        ##### THIS IS LEARNER #####
-        gamma = 0.99
-        lam = 0.95
-
         ent_coef = 0.0
         vf_coef = 0.5
         max_grad_norm = 0.5
@@ -81,10 +77,6 @@ class DiscreteIRLPolicy(StochasticPolicy, Serializable):
         )
 
         self.num_envs=num_envs
-
-        self.gamma = gamma
-        self.lam = lam
-        ##### END OF GIANT GOB OF LEARNER #####
 
         with tf.variable_scope(name) as scope:
             policy = policies.Policy(model_args)

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -80,6 +80,8 @@ class DiscreteIRLPolicy(StochasticPolicy, Serializable):
         self.baselines_venv = baselines_venv
         print("Environment: ", self.baselines_venv)
 
+
+
         with tf.variable_scope(name) as scope:
             self.learner = training.Learner(
                 policy_class=policy_model,
@@ -668,7 +670,6 @@ def get_training_kwargs(
             envs=envs, baseline_wrappers=baseline_wrappers
         ),
         irl_model=irl_model,
-        sampler_args={},
         baseline=ZeroBaseline(env_spec=envs.spec),
         ablation=ablation,
     )

--- a/atari_irl/irl.py
+++ b/atari_irl/irl.py
@@ -664,17 +664,11 @@ def get_training_kwargs(
     baselines_venv = baselines_venv
 
     nsteps = 2048
-    total_timesteps = 10e6
-    nminibatches = 4
-    noptepochs = 4
-    lr = 3e-4
-    cliprange = 0.2
-    total_timesteps = int(total_timesteps)
     batching_config = training.make_batching_config(
         nenvs=baselines_venv.num_envs,
         nsteps=nsteps,
-        noptepochs=noptepochs,
-        nminibatches=nminibatches
+        noptepochs=4,
+        nminibatches=4
     )
     policy_cfg['batching_config'] = batching_config
 
@@ -696,9 +690,9 @@ def get_training_kwargs(
         ),
         optimizer_args=dict(
             batching_config=batching_config,
-            lr=lr,
-            cliprange=cliprange,
-            total_timesteps=total_timesteps
+            lr=3e-4,
+            cliprange=0.2,
+            total_timesteps=10e6
         )
     )
     training_kwargs.update(

--- a/atari_irl/optimizers.py
+++ b/atari_irl/optimizers.py
@@ -72,16 +72,13 @@ class PPOOptimizer:
     def __init__(
             self,
             *,
-            policy,
             batching_config: BatchingConfig,
             lr=3e-4,
             cliprange=0.2,
             total_timesteps=10e6
     ):
         # Deal with the policy
-        self.policy = policy
-        assert hasattr(policy, 'model')
-        assert isinstance(policy.model, Model)
+        self.policy = None
 
         # Set things based on the batching config
         self.batching_config = batching_config
@@ -100,6 +97,11 @@ class PPOOptimizer:
 
         self.lr = lr
         self.cliprange = cliprange
+
+    def update_opt(self, policy):
+        self.policy = policy
+        assert hasattr(policy, 'model')
+        assert isinstance(policy.model, Model)
 
     def optimize_policy(self, itr: int, ppo_batch: PPOBatch):
         # compute our learning rate and clip ranges

--- a/atari_irl/optimizers.py
+++ b/atari_irl/optimizers.py
@@ -1,0 +1,119 @@
+from baselines.ppo2.ppo2 import Model, constfn
+from .sampling import PPOBatch
+
+import numpy as np
+
+from collections import namedtuple
+
+BatchingConfig = namedtuple('BatchingInfo', [
+    'nbatch', 'nbatch_train', 'noptepochs', 'nenvs', 'nsteps', 'nminibatches'
+])
+
+def make_batching_config(*, nenvs, nsteps, noptepochs, nminibatches):
+    nbatch = nenvs * nsteps
+    nbatch_train = nbatch // nminibatches
+    return BatchingConfig(
+        nbatch=nbatch, nbatch_train=nbatch_train, noptepochs=noptepochs,
+        nenvs=nenvs, nsteps=nsteps, nminibatches=nminibatches
+    )
+
+
+def ppo_train_steps(
+        *,
+        model: Model,
+        run_info: PPOBatch,
+        batching_config: BatchingConfig,
+        lrnow: float,
+        cliprangenow: float,
+        nbatch_train: int
+): # I'm not quite sure what type mblossvals is
+    states = run_info.states
+    nbatch, noptepochs = batching_config.nbatch, batching_config.noptepochs
+    nenvs, nminibatches = batching_config.nenvs, batching_config.nminibatches
+    nsteps = batching_config.nsteps
+
+    mblossvals = []
+    if states is None:  # nonrecurrent version
+        inds = np.arange(nbatch)
+        for _ in range(noptepochs):
+            np.random.shuffle(inds)
+            for start in range(0, nbatch, nbatch_train):
+                end = start + nbatch_train
+                mbinds = inds[start:end]
+                slices = (arr[mbinds] for arr in run_info.train_args())
+                mblossvals.append(model.train(lrnow, cliprangenow, *slices))
+
+    else:  # recurrent version
+        assert nenvs % nminibatches == 0
+        envsperbatch = nenvs // nminibatches
+        envinds = np.arange(nenvs)
+        flatinds = np.arange(nenvs * nsteps).reshape(nenvs, nsteps)
+        envsperbatch = nbatch_train // nsteps
+        for _ in range(noptepochs):
+            np.random.shuffle(envinds)
+            for start in range(0, nenvs, envsperbatch):
+                end = start + envsperbatch
+                mbenvinds = envinds[start:end]
+                mbflatinds = flatinds[mbenvinds].ravel()
+                slices = (arr[mbflatinds] for arr in run_info.train_args())
+                mbstates = states[mbenvinds]
+                mblossvals.append(model.train(lrnow, cliprangenow, *slices, mbstates))
+
+    return mblossvals
+
+
+class PPOOptimizer:
+    def __init__(
+            self,
+            *,
+            policy,
+            batching_config: BatchingConfig,
+
+            lr=3e-4,
+            cliprange=0.2,
+
+            total_timesteps=10e6
+    ):
+        # Deal with the policy
+        self.policy = policy
+        assert hasattr(policy, 'model')
+        assert isinstance(policy.model, Model)
+
+        # Set things based on the batching config
+        self.batching_config = batching_config
+        self.nbatch = self.batching_config.nbatch
+        self.nupdates = total_timesteps // self.batching_config.nbatch
+
+        # Deal with constant arguments
+        if isinstance(lr, float):
+            lr = constfn(lr)
+        else:
+            assert callable(lr)
+        if isinstance(cliprange, float):
+            cliprange = constfn(cliprange)
+        else:
+            assert callable(cliprange)
+
+        self.lr = lr
+        self.cliprange = cliprange
+
+    def optimize_policy(self, itr: int, ppo_batch: PPOBatch):
+        # compute our learning rate and clip ranges
+        assert self.nbatch % self.batching_config.nminibatches == 0
+        nbatch_train = self.nbatch // self.batching_config.nminibatches
+        frac = 1.0 - (itr - 1.0) / self.nupdates
+        assert frac > 0.0
+        lrnow = self.lr(frac)
+        cliprangenow = self.cliprange(frac)
+
+        # Run the training steps for PPO
+        mblossvals = ppo_train_steps(
+            model=self.policy.model,
+            run_info=ppo_batch,
+            batching_config=self.batching_config,
+            lrnow=lrnow,
+            cliprangenow=cliprangenow,
+            nbatch_train=nbatch_train
+        )
+
+        return np.mean(mblossvals, axis=0)

--- a/atari_irl/optimizers.py
+++ b/atari_irl/optimizers.py
@@ -5,6 +5,12 @@ import numpy as np
 
 from collections import namedtuple
 
+
+"""
+Heavily based on the ppo2 implementation found in the OpenAI baselines library,
+particularly the ppo_trainsteps function.
+"""
+
 BatchingConfig = namedtuple('BatchingInfo', [
     'nbatch', 'nbatch_train', 'noptepochs', 'nenvs', 'nsteps', 'nminibatches'
 ])

--- a/atari_irl/optimizers.py
+++ b/atari_irl/optimizers.py
@@ -74,10 +74,8 @@ class PPOOptimizer:
             *,
             policy,
             batching_config: BatchingConfig,
-
             lr=3e-4,
             cliprange=0.2,
-
             total_timesteps=10e6
     ):
         # Deal with the policy

--- a/atari_irl/sampling.py
+++ b/atari_irl/sampling.py
@@ -195,7 +195,7 @@ class PPOBatchSampler(BaseSampler, ppo2.AbstractEnvRunner):
     # airl interfaced code, use this.
     def __init__(self, algo, *, nsteps):
         model = algo.policy.model
-        env = algo.env._wrapped_env.venv
+        env = algo.policy.baselines_venv
         # The biggest weird thing about this piece of code is that it does a
         # a bunch of work to handle the context of what happens if the model
         # that we're training is actually recurrent.
@@ -239,7 +239,8 @@ class PPOBatchSampler(BaseSampler, ppo2.AbstractEnvRunner):
             mb_neglogpacs.append(neglogpacs)
             mb_dones.append(self.dones)
 
-            should_show = False # np.random.random() > .95
+            should_show = False and np.random.random() > .95
+
             if should_show:
                 print()
                 obs_summaries = '\t'.join([f"{o[0,0,0]}{o[0,-1,0]}" for o in self.obs])
@@ -253,6 +254,7 @@ class PPOBatchSampler(BaseSampler, ppo2.AbstractEnvRunner):
                 rew = '\t'.join(['{:.3f}'.format(r) for r in rewards])
                 print(f"Reward:\t{rew}")
                 print()
+
 
             for info in infos:
                 maybeepinfo = info.get('episode')

--- a/atari_irl/sampling.py
+++ b/atari_irl/sampling.py
@@ -193,7 +193,7 @@ class PPOSample:
 class PPOBatchSampler(BaseSampler, ppo2.AbstractEnvRunner):
     # If you want to use the baselines PPO sampler as a sampler for the
     # airl interfaced code, use this.
-    def __init__(self, *, env, model, nsteps):
+    def __init__(self, algo, *, env, model, nsteps):
         # The biggest weird thing about this piece of code is that it does a
         # a bunch of work to handle the context of what happens if the model
         # that we're training is actually recurrent.
@@ -201,6 +201,7 @@ class PPOBatchSampler(BaseSampler, ppo2.AbstractEnvRunner):
         # we can continue a run.
         # We have not actually tested that functionality
         ppo2.AbstractEnvRunner.__init__(self, env=env, model=model, nsteps=nsteps)
+        self.algo = algo
         self.env = env
         self.model = model
         self.nsteps = nsteps
@@ -358,7 +359,8 @@ class PPOBatchSampler(BaseSampler, ppo2.AbstractEnvRunner):
         return samples
 
     def process_samples(self, itr, paths):
-        ppo_batch = self.cur_sample.to_ppo_batch()
+        # TODO(Aaron): Set these in self
+        ppo_batch = self.cur_sample.to_ppo_batch(gamma=0.99, lam=0.95)
         self.algo.policy.learner._run_info = ppo_batch
         self.algo.policy.learner._epinfobuf.extend(ppo_batch.epinfos)
         return ppo_batch

--- a/atari_irl/sampling.py
+++ b/atari_irl/sampling.py
@@ -361,9 +361,7 @@ class PPOBatchSampler(BaseSampler, ppo2.AbstractEnvRunner):
 
     def obtain_samples(self, itr):
         self.cur_sample = self._sample()
-        samples = self.cur_sample.to_trajectories()
-        self.algo.irl_model._insert_next_state(samples)
-        return samples
+        return self.cur_sample
 
     def process_samples(self, itr, paths):
         ppo_batch = self.cur_sample.to_ppo_batch()

--- a/atari_irl/sampling.py
+++ b/atari_irl/sampling.py
@@ -193,9 +193,9 @@ class PPOSample:
 class PPOBatchSampler(BaseSampler, ppo2.AbstractEnvRunner):
     # If you want to use the baselines PPO sampler as a sampler for the
     # airl interfaced code, use this.
-    def __init__(self, algo, *, nsteps):
+    def __init__(self, algo, *, nsteps, baselines_venv):
         model = algo.policy.model
-        env = algo.policy.baselines_venv
+        env = baselines_venv
         # The biggest weird thing about this piece of code is that it does a
         # a bunch of work to handle the context of what happens if the model
         # that we're training is actually recurrent.
@@ -363,7 +363,6 @@ class PPOBatchSampler(BaseSampler, ppo2.AbstractEnvRunner):
         return samples
 
     def process_samples(self, itr, paths):
-        # TODO(Aaron): Set these in self
         ppo_batch = self.cur_sample.to_ppo_batch(gamma=0.99, lam=0.95)
         self._epinfobuf.extend(ppo_batch.epinfos)
         return ppo_batch

--- a/atari_irl/sampling.py
+++ b/atari_irl/sampling.py
@@ -244,6 +244,11 @@ class PPOBatchSampler(BaseSampler, ppo2.AbstractEnvRunner):
 
             self.obs[:], rewards, self.dones, infos = self.env.step(actions)
 
+            if np.random.random() < .001:
+                import pdb; pdb.set_trace()
+
+            self.env.render()
+
             if should_show:
                 rew = '\t'.join(['{:.3f}'.format(r) for r in rewards])
                 print(f"Reward:\t{rew}")

--- a/atari_irl/sampling.py
+++ b/atari_irl/sampling.py
@@ -9,6 +9,11 @@ from sandbox.rocky.tf.samplers.vectorized_sampler import VectorizedSampler
 
 from baselines.ppo2 import ppo2
 
+"""
+Heavily based on the ppo2 implementation found in the OpenAI baselines library,
+particularly in the PPOSampler class.
+"""
+
 # This is a PPO Batch that the OpenAI Baselines PPO code uses as its underlying
 # representation
 PPOBatch = namedtuple('PPOBatch', [

--- a/atari_irl/sampling.py
+++ b/atari_irl/sampling.py
@@ -7,6 +7,8 @@ from rllab.misc.overrides import overrides
 from rllab.sampler.base import BaseSampler
 from sandbox.rocky.tf.samplers.vectorized_sampler import VectorizedSampler
 
+from baselines.ppo2 import ppo2
+
 # This is a PPO Batch that the OpenAI Baselines PPO code uses as its underlying
 # representation
 PPOBatch = namedtuple('PPOBatch', [
@@ -98,7 +100,7 @@ class PPOSample:
     """
     def __init__(
             self, obs, rewards, actions, values, dones, neglogpacs, states,
-            epinfos, runner
+            epinfos, sampler
     ):
         self.obs = np.asarray(obs)
         self.rewards = np.asarray(rewards)
@@ -108,23 +110,21 @@ class PPOSample:
         self.neglogpacs = np.asarray(neglogpacs)
         self.states = states
         self.epinfos = epinfos
-        self.runner = runner
+
+        self.sampler = sampler
 
         self.sample_batch_timesteps = self.obs.shape[0]
         self.sample_batch_num_envs = self.obs.shape[1]
         self.sample_batch_size = (
             self.sample_batch_timesteps * self.sample_batch_num_envs
         )
-        self.train_batch_size = self.runner.model.train_model.X.shape[0].value
+        self.train_batch_size = self.sampler.model.train_model.X.shape[0].value
         assert self.sample_batch_size % self.train_batch_size == 0
 
         self.probabilities = self._get_sample_probabilities()
 
-    def to_ppo_batch(self) -> PPOBatch:
-        return PPOBatch(*self.runner.process_ppo_samples(
-            self.obs, self.rewards, self.actions, self.values, self.dones,
-            self.neglogpacs, self.states, self.epinfos
-        ))
+    def to_ppo_batch(self, *, gamma, lam) -> PPOBatch:
+        return self.sampler.process_to_ppo_batch(self, gamma=gamma, lam=lam)
 
     def _ravel_time_env_batch_to_train_batch(self, inpt):
         assert inpt.shape[0] == self.sample_batch_timesteps
@@ -154,12 +154,10 @@ class PPOSample:
 
     def _get_sample_probabilities(self):
         train_batched_obs = self._ravel_time_env_batch_to_train_batch(self.obs)
-        sess = tf.get_default_session()
-        tm = self.runner.model.train_model
         ps = np.asarray([
             # we weirdly don't have direct access to the probabilities anywhere
             # so we need to construct this node from teh logits
-            sess.run(tf.nn.softmax(tm.pd.logits), {tm.X: train_batch_obs})
+            self.sampler.get_probabilities_for_obs(train_batch_obs)
             for train_batch_obs in train_batched_obs
         ])
         return self._ravel_train_batch_to_time_env_batch(ps)
@@ -187,12 +185,20 @@ class PPOSample:
         return Trajectories(buffer, self)
 
 
-class PPOBatchSampler(BaseSampler):
+class PPOBatchSampler(BaseSampler, ppo2.AbstractEnvRunner):
     # If you want to use the baselines PPO sampler as a sampler for the
     # airl interfaced code, use this.
-    def __init__(self, algo):
-        super(PPOBatchSampler, self).__init__(algo)
-        assert isinstance(algo.policy.learner, training.Learner)
+    def __init__(self, *, env, model, nsteps):
+        # The biggest weird thing about this piece of code is that it does a
+        # a bunch of work to handle the context of what happens if the model
+        # that we're training is actually recurrent.
+        # This means that we store the observations, states, and dones so that
+        # we can continue a run.
+        # We have not actually tested that functionality
+        ppo2.AbstractEnvRunner.__init__(self, env=env, model=model, nsteps=nsteps)
+        self.env = env
+        self.model = model
+        self.nsteps = nsteps
         self.cur_sample = None
 
     def start_worker(self):
@@ -201,8 +207,144 @@ class PPOBatchSampler(BaseSampler):
     def shutdown_worker(self):
         pass
 
+    def run(self):
+        return self._sample()
+
+    def get_probabilities_for_obs(self, obs):
+        tm = self.model.train_model
+        return tf.get_default_session().run(
+            tf.nn.softmax(tm.pd.logits),
+            {tm.X: obs}
+        )
+
+    def _sample(self) -> PPOSample:
+        mb_obs, mb_rewards, mb_actions, mb_values, mb_dones, mb_neglogpacs = [],[],[],[],[],[]
+        mb_states = self.states
+        epinfos = []
+        for _ in range(self.nsteps):
+            actions, values, self.states, neglogpacs = self.model.step(self.obs, self.states, self.dones)
+            mb_obs.append(self.obs.copy())
+            mb_actions.append(actions)
+            mb_values.append(values)
+            mb_neglogpacs.append(neglogpacs)
+            mb_dones.append(self.dones)
+
+            should_show = False # np.random.random() > .95
+            if should_show:
+                print()
+                obs_summaries = '\t'.join([f"{o[0,0,0]}{o[0,-1,0]}" for o in self.obs])
+                act_summaries = '\t'.join([str(a) for a in actions])
+                print(f"State:\t{obs_summaries}")
+                print(f"Action:\t{act_summaries}")
+
+            self.obs[:], rewards, self.dones, infos = self.env.step(actions)
+
+            if should_show:
+                rew = '\t'.join(['{:.3f}'.format(r) for r in rewards])
+                print(f"Reward:\t{rew}")
+                print()
+
+            for info in infos:
+                maybeepinfo = info.get('episode')
+                if maybeepinfo:
+                    epinfos.append(maybeepinfo)
+            mb_rewards.append(rewards)
+
+        return PPOSample(
+            mb_obs, mb_rewards, mb_actions, mb_values, mb_dones,
+            mb_neglogpacs, mb_states, epinfos, self
+        )
+
+    def _process_ppo_samples(
+            self, *,
+            obs, rewards, actions, values, dones, neglogpacs,
+            states, epinfos,
+            gamma, lam
+    ) -> PPOBatch:
+        #batch of steps to batch of rollouts
+        mb_obs = np.asarray(obs, dtype=self.obs.dtype)
+        mb_rewards = np.asarray(rewards, dtype=np.float32)
+        mb_actions = np.asarray(actions)
+        mb_values = np.asarray(values, dtype=np.float32)
+        mb_dones = np.asarray(dones, dtype=np.bool)
+        mb_neglogpacs = np.asarray(neglogpacs, dtype=np.float32)
+        last_values = self.model.value(self.obs, self.states, self.dones)
+        #discount/bootstrap off value fn
+        mb_advs = np.zeros_like(mb_rewards)
+        lastgaelam = 0
+        for t in reversed(range(self.nsteps)):
+            if t == self.nsteps - 1:
+                nextnonterminal = 1.0 - self.dones
+                nextvalues = last_values
+            else:
+                nextnonterminal = 1.0 - mb_dones[t+1]
+                nextvalues = mb_values[t+1]
+            delta = mb_rewards[t] + gamma * nextvalues * nextnonterminal - mb_values[t]
+            mb_advs[t] = lastgaelam = delta + gamma * lam * nextnonterminal * lastgaelam
+        mb_returns = mb_advs + mb_values
+        return PPOBatch(
+            *map(
+                ppo2.sf01,
+                (mb_obs, mb_returns, mb_dones, mb_actions, mb_values, mb_neglogpacs)
+            ),
+            states,
+            epinfos
+        )
+
+    def process_to_ppo_batch(
+            self, ppo_sample: PPOSample, *, gamma: float, lam: float
+    ) -> PPOBatch:
+        return self._process_ppo_samples(
+            obs=ppo_sample.obs,
+            rewards=ppo_sample.rewards,
+            actions=ppo_sample.actions,
+            values=ppo_sample.actions,
+            dones=ppo_sample.dones,
+            neglogpacs=ppo_sample.neglogpacs,
+            states=ppo_sample.states,
+            epinfos=ppo_sample.epinfos,
+            gamma=gamma, lam=lam
+        )
+
+    def process_trajectory(self, traj, *, gamma, lam):
+        def batch_reshape(single_traj_data):
+            single_traj_data = np.asarray(single_traj_data)
+            s = single_traj_data.shape
+            return single_traj_data.reshape(s[0], 1, *s[1:])
+
+        agent_info = traj['agent_infos']
+
+        # These are trying to deal with the fact that the PPOSampler maintains
+        # an internal state that it uses to remember information between
+        # trajectories, which is important if you have a recurrent policy
+        self.state = None
+        self.obs[:] = traj['observations'][-1]
+        self.dones = np.ones(self.env.num_envs)
+        dones = np.zeros(agent_info['values'].shape)
+        # This is a full trajectory, so it's a bunch of not-done, followed by
+        # a single done
+        dones[-1] = 1
+
+        # This is actually kind of weird w/r/t to the PPO code, because the
+        # batch length is so much longer. Maybe this will work? But if PPO
+        # ablations don't crash, but fail to learn this is probably why.
+        return self._process_ppo_samples(
+            # The easy stuff that we just observe
+            obs=batch_reshape(traj['observations']),
+            rewards=np.hstack([batch_reshape(traj['rewards']) for _ in range(8)]),
+            actions=batch_reshape(traj['actions']).argmax(axis=1),
+            # now the things from the agent info
+            values=agent_info['values'],
+            dones=dones,
+            neglogpacs=agent_info['neglogpacs'],
+            states=None, # recurrent trajectories should include states
+            # and the annotations
+            epinfos=traj['env_infos'],
+            gamma=gamma, lam=lam
+        )
+
     def obtain_samples(self, itr):
-        self.cur_sample = self.algo.policy.learner.runner.sample()
+        self.cur_sample = self._sample()
         samples = self.cur_sample.to_trajectories()
         self.algo.irl_model._insert_next_state(samples)
         return samples

--- a/atari_irl/sampling.py
+++ b/atari_irl/sampling.py
@@ -244,9 +244,6 @@ class PPOBatchSampler(BaseSampler, ppo2.AbstractEnvRunner):
 
             self.obs[:], rewards, self.dones, infos = self.env.step(actions)
 
-            if np.random.random() < .001:
-                import pdb; pdb.set_trace()
-
             self.env.render()
 
             if should_show:
@@ -258,6 +255,7 @@ class PPOBatchSampler(BaseSampler, ppo2.AbstractEnvRunner):
                 maybeepinfo = info.get('episode')
                 if maybeepinfo:
                     epinfos.append(maybeepinfo)
+
             mb_rewards.append(rewards)
 
         return PPOSample(
@@ -308,7 +306,7 @@ class PPOBatchSampler(BaseSampler, ppo2.AbstractEnvRunner):
             obs=ppo_sample.obs,
             rewards=ppo_sample.rewards,
             actions=ppo_sample.actions,
-            values=ppo_sample.actions,
+            values=ppo_sample.values,
             dones=ppo_sample.dones,
             neglogpacs=ppo_sample.neglogpacs,
             states=ppo_sample.states,

--- a/atari_irl/training.py
+++ b/atari_irl/training.py
@@ -6,7 +6,7 @@ from baselines.ppo2.ppo2 import constfn, safemean
 from baselines.ppo2 import ppo2
 
 from . import policies, utils
-from .sampling import PPOSample
+from .sampling import PPOBatchSampler
 from .optimizers import PPOOptimizer, make_batching_config
 
 from collections import deque, namedtuple
@@ -113,105 +113,13 @@ class Runner(ppo2.AbstractEnvRunner):
         super().__init__(env=env, model=model, nsteps=nsteps)
         self.lam = lam
         self.gamma = gamma
+        self.sampler = PPOBatchSampler(env=env, model=model, nsteps=nsteps)
 
     def sample(self):
-        mb_obs, mb_rewards, mb_actions, mb_values, mb_dones, mb_neglogpacs = [],[],[],[],[],[]
-        mb_states = self.states
-        epinfos = []
-        for _ in range(self.nsteps):
-            actions, values, self.states, neglogpacs = self.model.step(self.obs, self.states, self.dones)
-            mb_obs.append(self.obs.copy())
-            mb_actions.append(actions)
-            mb_values.append(values)
-            mb_neglogpacs.append(neglogpacs)
-            mb_dones.append(self.dones)
+        return self.sampler.run()
 
-            should_show = False # np.random.random() > .95
-            if should_show:
-                print()
-                obs_summaries = '\t'.join([f"{o[0,0,0]}{o[0,-1,0]}" for o in self.obs])
-                act_summaries = '\t'.join([str(a) for a in actions])
-                print(f"State:\t{obs_summaries}")
-                print(f"Action:\t{act_summaries}")
-
-            self.obs[:], rewards, self.dones, infos = self.env.step(actions)
-
-            #self.env.render()
-
-            if should_show:
-                rew = '\t'.join(['{:.3f}'.format(r) for r in rewards])
-                print(f"Reward:\t{rew}")
-                print()
-
-            for info in infos:
-                maybeepinfo = info.get('episode')
-                if maybeepinfo:
-                    epinfos.append(maybeepinfo)
-            mb_rewards.append(rewards)
-
-        return PPOSample(
-            mb_obs, mb_rewards, mb_actions, mb_values, mb_dones,
-            mb_neglogpacs, mb_states, epinfos, self
-        )
-
-    def process_ppo_samples(
-            self, mb_obs, mb_rewards, mb_actions, mb_values, mb_dones, mb_neglogpacs,
-            mb_states, epinfos
-    ):
-        #batch of steps to batch of rollouts
-        mb_obs = np.asarray(mb_obs, dtype=self.obs.dtype)
-        mb_obs = np.asarray(mb_obs, dtype=self.obs.dtype)
-        mb_rewards = np.asarray(mb_rewards, dtype=np.float32)
-        mb_actions = np.asarray(mb_actions)
-        mb_values = np.asarray(mb_values, dtype=np.float32)
-        mb_neglogpacs = np.asarray(mb_neglogpacs, dtype=np.float32)
-        mb_dones = np.asarray(mb_dones, dtype=np.bool)
-        last_values = self.model.value(self.obs, self.states, self.dones)
-        #discount/bootstrap off value fn
-        mb_returns = np.zeros_like(mb_rewards)
-        mb_advs = np.zeros_like(mb_rewards)
-        lastgaelam = 0
-        for t in reversed(range(self.nsteps)):
-            if t == self.nsteps - 1:
-                nextnonterminal = 1.0 - self.dones
-                nextvalues = last_values
-            else:
-                nextnonterminal = 1.0 - mb_dones[t+1]
-                nextvalues = mb_values[t+1]
-            delta = mb_rewards[t] + self.gamma * nextvalues * nextnonterminal - mb_values[t]
-            mb_advs[t] = lastgaelam = delta + self.gamma * self.lam * nextnonterminal * lastgaelam
-        mb_returns = mb_advs + mb_values
-        return (*map(ppo2.sf01, (mb_obs, mb_returns, mb_dones, mb_actions, mb_values, mb_neglogpacs)),
-            mb_states, epinfos)
-
-    def process_trajectory(self, traj):
-        def batch_reshape(single_traj_data):
-            single_traj_data = np.asarray(single_traj_data)
-            s = single_traj_data.shape
-            return single_traj_data.reshape(s[0], 1, *s[1:])
-
-        agent_info = traj['agent_infos']
-        self.state = None
-        self.obs[:] = traj['observations'][-1]
-        self.dones = np.ones(self.env.num_envs)
-        dones = np.zeros(agent_info['values'].shape)
-        dones[-1] = 1
-        # This is actually kind of weird w/r/t to the PPO code, because the
-        # batch length is so much longer. Maybe this will work? But if PPO
-        # ablations don't crash, but fail to learn this is probably why.
-        return self.process_ppo_samples(
-            # The easy stuff that we just observe
-            batch_reshape(traj['observations']),
-            np.hstack([batch_reshape(traj['rewards']) for _ in range(8)]),
-            batch_reshape(traj['actions']).argmax(axis=1),
-            # now the things from the agent info
-            agent_info['values'], dones, agent_info['neglogpacs'],
-            # and the annotations
-            None, traj['env_infos']
-        )
-
-    def run(self):
-        return self.sample().to_ppo_batch()
+    def run(self, gamma=.99, lam=.95):
+        return self.sample().to_ppo_batch(gamma=self.gamma, lam=self.lam)
 
 
 class Learner:

--- a/atari_irl/training.py
+++ b/atari_irl/training.py
@@ -2,10 +2,10 @@ import numpy as np
 
 from baselines import logger
 from baselines.common import explained_variance
-from baselines.ppo2.ppo2 import constfn, safemean
+from baselines.ppo2.ppo2 import safemean
 from baselines.ppo2 import ppo2
 
-from . import policies, utils
+from . import policies
 from .sampling import PPOBatchSampler
 from .optimizers import PPOOptimizer, make_batching_config
 
@@ -167,14 +167,6 @@ class Learner:
     @property
     def update(self):
         return self._update
-
-    @property
-    def mean_reward(self):
-        return safemean([epinfo['r'] for epinfo in self._epinfobuf])
-
-    @property
-    def mean_length(self):
-        return safemean([epinfo['l'] for epinfo in self._epinfobuf])
 
     def obtain_samples(self, itr):
         # Run the model on the environments

--- a/atari_irl/training.py
+++ b/atari_irl/training.py
@@ -137,7 +137,10 @@ class Learner:
 
         model = policy.model
         sampler = PPOBatchSampler(env=env, model=model, nsteps=nsteps)
-        optimizer = PPOOptimizer(policy=policy, batching_config=batching_config)
+        optimizer = PPOOptimizer(
+            policy=policy, batching_config=batching_config,
+            lr=lr, cliprange=cliprange, total_timesteps=total_timesteps
+        )
 
         self.gamma = gamma
         self.lam = lam

--- a/tests/test_irl.py
+++ b/tests/test_irl.py
@@ -56,11 +56,16 @@ class TestAtariIRL:
         with utils.EnvironmentContext(
             env_name=self.env, n_envs=8, seed=0, **self.env_modifiers
         ) as env_context:
-            with irl.IRLContext(self.config, seed=0) as irl_context:
-                training_kwargs, _, _ = irl.get_training_kwargs(
+            with irl.IRLContext(self.config, env_config={
+                'seed': 0,
+                'env_name': 'PongNoFrameskip-v4',
+                'one_hot_code': True
+            }):
+                training_kwargs, _, _, _ = irl.get_training_kwargs(
                     venv=env_context.environments,
-                    irl_context=irl_context,
-                    expert_trajectories=pickle.load(open('scripts/short_trajectories.pkl', 'rb')),
+                    reward_model_cfg={
+                        'expert_trajs': pickle.load(open('scripts/short_trajectories.pkl', 'rb')),
+                    }
                 )
                 print("Training arguments: ", training_kwargs)
                 algo = irl.IRLRunner(**training_kwargs)
@@ -71,11 +76,16 @@ class TestAtariIRL:
         with utils.EnvironmentContext(
             env_name=self.env, n_envs=1, seed=0, **self.env_modifiers
         ) as env_context:
-            with irl.IRLContext(self.config, seed=0) as irl_context:
-                training_kwargs, _, _ = irl.get_training_kwargs(
+            with irl.IRLContext(self.config, env_config={
+                'seed': 0,
+                'env_name': 'PongNoFrameskip-v4',
+                'one_hot_code': True
+            }):
+                training_kwargs, _, _, _ = irl.get_training_kwargs(
                     venv=env_context.environments,
-                    irl_context=irl_context,
-                    expert_trajectories=pickle.load(open('scripts/short_trajectories.pkl', 'rb')),
+                    reward_model_cfg={
+                        'expert_trajs': pickle.load(open('scripts/short_trajectories.pkl', 'rb')),
+                    }
                 )
                 training_kwargs['batch_size'] = 50
                 print("Training arguments: ", training_kwargs)
@@ -111,11 +121,16 @@ class TestAtariIRL:
         with utils.EnvironmentContext(
             env_name=self.env, n_envs=8, seed=0, **self.env_modifiers
         ) as env_context:
-            with irl.IRLContext(self.config, seed=0) as irl_context:
-                training_kwargs, _, _ = irl.get_training_kwargs(
+            with irl.IRLContext(self.config, env_config={
+                'seed': 0,
+                'env_name': 'PongNoFrameskip-v4',
+                'one_hot_code': True
+            }):
+                training_kwargs, _, _, _ = irl.get_training_kwargs(
                     venv=env_context.environments,
-                    irl_context=irl_context,
-                    expert_trajectories=pickle.load(open('scripts/short_trajectories.pkl', 'rb')),
+                    reward_model_cfg={
+                        'expert_trajs': pickle.load(open('scripts/short_trajectories.pkl', 'rb')),
+                    }
                 )
                 training_kwargs['batch_size'] = 50
                 print("Training arguments: ", training_kwargs)
@@ -128,12 +143,12 @@ class TestAtariIRL:
                 assert_trajectory_formatted(trajectories.trajectories)
                 roundtrip_sample = trajectories.to_ppo_sample()
 
-                assert ppo_sample.obs == roundtrip_sample.obs
-                assert ppo_sample.rewards == roundtrip_sample.rewards
-                assert ppo_sample.actions == roundtrip_sample.actions
-                assert ppo_sample.values == roundtrip_sample.values
-                assert ppo_sample.dones == roundtrip_sample.dones
-                assert ppo_sample.neglogpacs == roundtrip_sample.neglogpacs
+                assert (ppo_sample.obs == roundtrip_sample.obs).all()
+                assert (ppo_sample.rewards == roundtrip_sample.rewards).all()
+                assert (ppo_sample.actions == roundtrip_sample.actions).all()
+                assert (ppo_sample.values == roundtrip_sample.values).all()
+                assert (ppo_sample.dones == roundtrip_sample.dones).all()
+                assert (ppo_sample.neglogpacs == roundtrip_sample.neglogpacs).all()
                 assert ppo_sample.states == roundtrip_sample.states
                 assert ppo_sample.epinfos == roundtrip_sample.epinfos
                 assert ppo_sample.runner == roundtrip_sample.runner
@@ -142,11 +157,16 @@ class TestAtariIRL:
         with utils.EnvironmentContext(
             env_name=self.env, n_envs=8, seed=0, **self.env_modifiers
         ) as env_context:
-            with irl.IRLContext(self.config, seed=0) as irl_context:
-                training_kwargs, _, _ = irl.get_training_kwargs(
+            with irl.IRLContext(self.config, env_config={
+                'seed': 0,
+                'env_name': 'PongNoFrameskip-v4',
+                'one_hot_code': True
+            }):
+                training_kwargs, _, _, _ = irl.get_training_kwargs(
                     venv=env_context.environments,
-                    irl_context=irl_context,
-                    expert_trajectories=pickle.load(open('scripts/short_trajectories.pkl', 'rb')),
+                    reward_model_cfg={
+                        'expert_trajs': pickle.load(open('scripts/short_trajectories.pkl', 'rb')),
+                    }
                 )
                 training_kwargs['batch_size'] = 50
                 print("Training arguments: ", training_kwargs)
@@ -178,11 +198,16 @@ class TestAtariIRL:
         with utils.EnvironmentContext(
             env_name=self.env, n_envs=8, seed=0, **self.env_modifiers
         ) as env_context:
-            with irl.IRLContext(self.config, seed=0) as irl_context:
-                training_kwargs, _, _ = irl.get_training_kwargs(
+            with irl.IRLContext(self.config, env_config={
+                'seed': 0,
+                'env_name': 'PongNoFrameskip-v4',
+                'one_hot_code': True
+            }):
+                training_kwargs, _, _, _ = irl.get_training_kwargs(
                     venv=env_context.environments,
-                    irl_context=irl_context,
-                    expert_trajectories=pickle.load(open('scripts/short_trajectories.pkl', 'rb')),
+                    reward_model_cfg={
+                        'expert_trajs': pickle.load(open('scripts/short_trajectories.pkl', 'rb')),
+                    }
                 )
                 training_kwargs['batch_size'] = 50
                 print("Training arguments: ", training_kwargs)


### PR DESCRIPTION
This refactors the code to actually separate out the responsibilities between sampling, optimization, and policy computation for PPO/baselines policies.

You still can't use every component with every other component, but now it's because of issues like the fact that the RLLab interfaces doesn't store/compute value computations, which the PPO code uses, rather than the fact that convoluted interface breaking logic is the default way of accessing information.

More concretely, rather than creating a Learner and wrapping it in a policy (then accessing the learner a lot of the time), we've split up the Policy from the PPOSampler and PPOOptimizer.